### PR TITLE
Show a message when no account services are set up

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,12 @@ jobs:
       artifactname: SpeziAccount.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziAccount
+  build:
+    name: Build Swift Package on Xcode 14
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macos-13"]'
+      scheme: SpeziAccount
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -31,12 +37,6 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'
       scheme: TestApp
-  build:
-    name: Build Swift Package on Xcode 14
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macos-13"]'
-      scheme: SpeziAccount
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [buildandtest, buildandtestuitests]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,9 +31,16 @@ jobs:
       runsonlabels: '["macOS", "self-hosted"]'
       path: 'Tests/UITests'
       scheme: TestApp
+  build:
+    name: Build Swift Package on Xcode 14
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      artifactname: SpeziAccount_Xcode14.xcresult
+      runsonlabels: '["macos-13"]'
+      scheme: SpeziAccount
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [buildandtest, buildandtestuitests]
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: SpeziAccount.xcresult TestApp.xcresult
+      coveragereports: SpeziAccount.xcresult SpeziAccount_Xcode14.xcresult TestApp.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,6 @@ jobs:
     name: Build Swift Package on Xcode 14
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
-      artifactname: SpeziAccount_Xcode14.xcresult
       runsonlabels: '["macos-13"]'
       scheme: SpeziAccount
   uploadcoveragereport:
@@ -43,4 +42,4 @@ jobs:
     needs: [buildandtest, buildandtestuitests]
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: SpeziAccount.xcresult SpeziAccount_Xcode14.xcresult TestApp.xcresult
+      coveragereports: SpeziAccount.xcresult TestApp.xcresult

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ Spezi Account Contributors
 ====================
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
+* [Andreas Bauer](https://github.com/Supereg)

--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -15,7 +15,8 @@ import SwiftUI
 /// The ``Account/Account`` type also enables interaction with the ``AccountService``s from anywhere in the view hierachy.
 public actor Account: ObservableObject {
     /// The ``Account/Account/signedIn`` determines if the the current Account context is signed in or not yet signed in.
-    @MainActor @Published
+    @MainActor
+    @Published
     public var signedIn = false
     
     ///  An account provides a collection of ``AccountService``s that are used to populate login, sign up, or reset password screens.

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -14,6 +14,14 @@ struct AccountServicesView<Header: View>: View {
 
     private var header: Header
     private var button: (any AccountService) -> AnyView
+
+    private var documentationUrl: URL {
+        guard let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice") else {
+            fatalError("Failed to construct SpeziAccount Documentation URL. Please review URL syntax!")
+        }
+
+        return docsUrl
+    }
     
     
     var body: some View {
@@ -28,10 +36,8 @@ struct AccountServicesView<Header: View>: View {
                                 .multilineTextAlignment(.center)
                                 .foregroundColor(.secondary)
 
-                            // swiftlint:disable:next force_unwrapping
-                            let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice")!
                             Button {
-                                UIApplication.shared.open(docsUrl)
+                                UIApplication.shared.open(documentationUrl)
                             } label: {
                                 Text("OPEN_DOCUMENTATION", bundle: .module)
                             }
@@ -77,7 +83,7 @@ struct AccountServicesView_Previews: PreviewProvider {
             AccountServicesView(header: EmptyView()) { accountService in
                 accountService.loginButton
             }
-            .navigationTitle(String(localized: "LOGIN", bundle: .module))
+                .navigationTitle(String(localized: "LOGIN", bundle: .module))
         }
             .environmentObject(account)
     }

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -9,7 +9,6 @@
 import Spezi
 import SwiftUI
 
-
 struct AccountServicesView<Header: View>: View {
     @EnvironmentObject var account: Account
     
@@ -24,8 +23,15 @@ struct AccountServicesView<Header: View>: View {
                     header
                     Spacer(minLength: 0)
                     VStack(spacing: 16) {
-                        ForEach(account.accountServices, id: \.id) { loginService in
-                            button(loginService)
+                        if account.accountServices.isEmpty {
+                            Text("MISSING_ACCOUNT_SERVICES", bundle: .module)
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(.secondary)
+                                .padding(.vertical, 16)
+                        } else {
+                            ForEach(account.accountServices, id: \.id) { loginService in
+                                button(loginService)
+                            }
                         }
                     }
                         .padding(16)
@@ -58,10 +64,13 @@ struct AccountServicesView_Previews: PreviewProvider {
         ]
         return Account(accountServices: accountServices)
     }()
-    
+
     static var previews: some View {
         NavigationStack {
-            Login()
+            AccountServicesView(header: EmptyView()) { accountService in
+                accountService.loginButton
+            }
+            .navigationTitle(String(localized: "LOGIN", bundle: .module))
         }
             .environmentObject(account)
     }

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 struct AccountServicesView<Header: View>: View {
     @EnvironmentObject var account: Account
-    
+    @Environment(\.openURL) private var openURL
+
     private var header: Header
     private var button: (any AccountService) -> AnyView
     
@@ -27,7 +28,15 @@ struct AccountServicesView<Header: View>: View {
                             Text("MISSING_ACCOUNT_SERVICES", bundle: .module)
                                 .multilineTextAlignment(.center)
                                 .foregroundColor(.secondary)
-                                .padding(.vertical, 16)
+
+                            let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice")!
+                            Button {
+                                openURL(docsUrl)
+                            } label: {
+                                Text("OPEN_DOCUMENTATION", bundle: .module)
+                            }
+
+
                         } else {
                             ForEach(account.accountServices, id: \.id) { loginService in
                                 button(loginService)

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 struct AccountServicesView<Header: View>: View {
     @EnvironmentObject var account: Account
-    @Environment(\.openURL) private var openURL
+    @Environment(\.openURL)
+    private var openURL
 
     private var header: Header
     private var button: (any AccountService) -> AnyView
@@ -29,14 +30,13 @@ struct AccountServicesView<Header: View>: View {
                                 .multilineTextAlignment(.center)
                                 .foregroundColor(.secondary)
 
+                            // swiftlint:disable:next force_unwrapping
                             let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice")!
                             Button {
                                 openURL(docsUrl)
                             } label: {
                                 Text("OPEN_DOCUMENTATION", bundle: .module)
                             }
-
-
                         } else {
                             ForEach(account.accountServices, id: \.id) { loginService in
                                 button(loginService)

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -16,6 +16,7 @@ struct AccountServicesView<Header: View>: View {
     private var button: (any AccountService) -> AnyView
 
     private var documentationUrl: URL {
+        // we may move to a #URL macro once Swift 5.9 is shipping
         guard let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice") else {
             fatalError("Failed to construct SpeziAccount Documentation URL. Please review URL syntax!")
         }

--- a/Sources/SpeziAccount/AccountServicesView.swift
+++ b/Sources/SpeziAccount/AccountServicesView.swift
@@ -11,8 +11,6 @@ import SwiftUI
 
 struct AccountServicesView<Header: View>: View {
     @EnvironmentObject var account: Account
-    @Environment(\.openURL)
-    private var openURL
 
     private var header: Header
     private var button: (any AccountService) -> AnyView
@@ -33,7 +31,7 @@ struct AccountServicesView<Header: View>: View {
                             // swiftlint:disable:next force_unwrapping
                             let docsUrl = URL(string: "https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/createanaccountservice")!
                             Button {
-                                openURL(docsUrl)
+                                UIApplication.shared.open(docsUrl)
                             } label: {
                                 Text("OPEN_DOCUMENTATION", bundle: .module)
                             }

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -38,17 +38,8 @@ public struct Login<Header: View>: View {
 
 #if DEBUG
 struct Login_Previews: PreviewProvider {
-    @StateObject private static var account: Account = {
-        let accountServices: [any AccountService] = [
-            UsernamePasswordAccountService(),
-            EmailPasswordAccountService()
-        ]
-        return Account(accountServices: accountServices)
-    }()
-
-    @StateObject private static var emptyAccount: Account = {
-        Account(accountServices: [])
-    }()
+    @StateObject private static var account: Account = Account(accountServices: [UsernamePasswordAccountService(), EmailPasswordAccountService()])
+    @StateObject private static var emptyAccount: Account = Account(accountServices: [])
     
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -36,7 +36,7 @@ public struct Login<Header: View>: View {
 }
 
 
-#if !TEST
+#if DEBUG
 struct Login_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -36,7 +36,7 @@ public struct Login<Header: View>: View {
 }
 
 
-#if DEBUG
+#if !TEST
 struct Login_Previews: PreviewProvider {
     @StateObject private static var account: Account = {
         let accountServices: [any AccountService] = [

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -30,7 +30,7 @@ public struct Login<Header: View>: View {
     }
     
     /// - Parameter header: A SwiftUI `View` displayed as a header above all login buttons.
-    public init(@ViewBuilder header: () -> (Header)) {
+    public init(@ViewBuilder header: () -> Header) {
         self.header = header()
     }
 }
@@ -45,13 +45,21 @@ struct Login_Previews: PreviewProvider {
         ]
         return Account(accountServices: accountServices)
     }()
-    
+
+    @StateObject private static var emptyAccount: Account = {
+        return Account(accountServices: [])
+    }()
     
     static var previews: some View {
         NavigationStack {
             Login()
         }
             .environmentObject(account)
+
+        NavigationStack {
+            Login()
+        }
+            .environmentObject(emptyAccount)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 /// Display login buttons for all configured ``AccountService``s using the ``Account/Account`` module.
 ///
-/// The view displaydefaultLocalization: "en",s a list of login buttons as well as a cusomizable header view that can be defined using the ``Login/init(header:)`` initializer.
+/// The view display default Localization: "en",s a list of login buttons as well as a customizable header view that can be defined using the ``Login/init(header:)`` initializer.
 public struct Login<Header: View>: View {
     private var header: Header
     
@@ -38,8 +38,8 @@ public struct Login<Header: View>: View {
 
 #if DEBUG
 struct Login_Previews: PreviewProvider {
-    @StateObject private static var account: Account = Account(accountServices: [UsernamePasswordAccountService(), EmailPasswordAccountService()])
-    @StateObject private static var emptyAccount: Account = Account(accountServices: [])
+    @StateObject private static var account = Account(accountServices: [UsernamePasswordAccountService(), EmailPasswordAccountService()])
+    @StateObject private static var emptyAccount = Account(accountServices: [])
     
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Login.swift
+++ b/Sources/SpeziAccount/Login.swift
@@ -47,7 +47,7 @@ struct Login_Previews: PreviewProvider {
     }()
 
     @StateObject private static var emptyAccount: Account = {
-        return Account(accountServices: [])
+        Account(accountServices: [])
     }()
     
     static var previews: some View {

--- a/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
@@ -9,6 +9,8 @@
 // MARK: - General Views
 "LOGIN" = "Anmelden";
 "SIGN_UP" = "Benutzerkonto Erstellen";
+"MISSING_ACCOUNT_SERVICES" = "Es wurden keine AccountServices konfiguriert.\n Bitte kontaktiere die Dokumentation von SpeziAccount für mehr Informationen zur Konfiguration eines AccountServices!";
+"OPEN_DOCUMENTATION" = "Dokumentation öffnen";
 
 // MARK: - Username Password
 

--- a/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
@@ -6,6 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
+// MARK: - General Views
+"LOGIN" = "Anmelden";
+"SIGN_UP" = "Benutzerkonto Erstellen";
+
 // MARK: - Username Password
 
 // Login

--- a/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
@@ -9,7 +9,8 @@
 // MARK: - General Views
 "LOGIN" = "Login";
 "SIGN_UP" = "Sign Up";
-"MISSING_ACCOUNT_SERVICES" = "No Account Services where set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!";
+"MISSING_ACCOUNT_SERVICES" = "No Account Services set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!";
+"OPEN_DOCUMENTATION" = "Open Documentation";
 
 // MARK: - Username Password
 

--- a/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 // MARK: - General Views
 "LOGIN" = "Login";
 "SIGN_UP" = "Sign Up";
+"MISSING_ACCOUNT_SERVICES" = "No Account Services where set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!";
 
 // MARK: - Username Password
 

--- a/Sources/SpeziAccount/SignUp.swift
+++ b/Sources/SpeziAccount/SignUp.swift
@@ -48,7 +48,7 @@ struct SignUp_Previews: PreviewProvider {
     
     static var previews: some View {
         NavigationStack {
-            Login()
+            SignUp()
         }
             .environmentObject(account)
     }

--- a/Sources/SpeziAccount/Username and Password/Localization/Localization+Login.swift
+++ b/Sources/SpeziAccount/Username and Password/Localization/Localization+Login.swift
@@ -10,7 +10,7 @@ import SpeziViews
 
 
 extension Localization {
-    /// Provides localization information for the login-related views in the Accont module.
+    /// Provides localization information for the login-related views in the Account module.
     ///
     /// The values passed into the ``Localization`` substructs are automatically interpreted according to the localization key mechanisms defined in the Spezi Views module.
     ///

--- a/Sources/SpeziAccount/Views/AccountServiceButton.swift
+++ b/Sources/SpeziAccount/Views/AccountServiceButton.swift
@@ -41,7 +41,7 @@ struct UsernamePasswordLoginServiceButton_Previews: PreviewProvider {
         AccountServiceButton {
             Image(systemName: "ellipsis.rectangle")
                 .font(.title2)
-            Text("LOGIN_UAP_BUTTON_TITLE", bundle: .module)
+            Text("UAP_LOGIN_BUTTON_TITLE", bundle: .module)
         }
     }
 }

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -17,6 +17,11 @@
           "name" : "SpeziAccount"
         }
       ]
+    },
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:UITests.xcodeproj",
+      "identifier" : "2F6D139128F5F384007C25D6",
+      "name" : "TestApp"
     }
   },
   "testTargets" : [

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -19,9 +19,9 @@
       ]
     },
     "targetForVariableExpansion" : {
-      "containerPath" : "container:..\/..",
-      "identifier" : "SpeziAccount",
-      "name" : "SpeziAccount"
+      "containerPath" : "container:UITests.xcodeproj",
+      "identifier" : "2F6D139128F5F384007C25D6",
+      "name" : "TestApp"
     }
   },
   "testTargets" : [

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -19,9 +19,9 @@
       ]
     },
     "targetForVariableExpansion" : {
-      "containerPath" : "container:UITests.xcodeproj",
-      "identifier" : "2F6D139128F5F384007C25D6",
-      "name" : "TestApp"
+      "containerPath" : "container:..\/..",
+      "identifier" : "SpeziAccount",
+      "name" : "SpeziAccount"
     }
   },
   "testTargets" : [

--- a/Tests/UITests/TestApp.xctestplan
+++ b/Tests/UITests/TestApp.xctestplan
@@ -9,10 +9,14 @@
     }
   ],
   "defaultOptions" : {
-    "targetForVariableExpansion" : {
-      "containerPath" : "container:UITests.xcodeproj",
-      "identifier" : "2F6D139128F5F384007C25D6",
-      "name" : "TestApp"
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:..\/..",
+          "identifier" : "SpeziAccount",
+          "name" : "SpeziAccount"
+        }
+      ]
     }
   },
   "testTargets" : [

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -71,6 +71,11 @@ struct AccountTestsView_Previews: PreviewProvider {
             AccountTestsView()
         }
             .environmentObject(account)
+
+        NavigationStack {
+            AccountTestsView()
+        }
+        .environmentObject(Account(accountServices: []))
     }
 }
 #endif

--- a/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
@@ -25,12 +25,14 @@ final class TestAccountConfiguration<ComponentStandard: Standard>: Component, Ob
     }
     
     
-    init() {
+    init(emptyAccountServices: Bool = false) {
         self.user = User()
-        let accountServices: [any AccountService] = [
-            MockUsernamePasswordAccountService(user: user),
-            MockEmailPasswordAccountService(user: user)
-        ]
+        let accountServices: [any AccountService] = emptyAccountServices
+            ? []
+            : [
+                MockUsernamePasswordAccountService(user: user),
+                MockEmailPasswordAccountService(user: user)
+            ]
         self.account = Account(accountServices: accountServices)
     }
 }

--- a/Tests/UITests/TestApp/FeatureFlags.swift
+++ b/Tests/UITests/TestApp/FeatureFlags.swift
@@ -1,0 +1,13 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+/// A collection of feature flags for the Test App.
+enum FeatureFlags {
+    /// Configures the SpeziAccount AccountServices to be empty!
+    static let emptyAccountServices = CommandLine.arguments.contains("--emptyAccountServices")
+}

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -12,7 +12,7 @@ import Spezi
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: TestAppStandard()) {
-            TestAccountConfiguration()
+            TestAccountConfiguration(emptyAccountServices: FeatureFlags.emptyAccountServices)
         }
     }
 }

--- a/Tests/UITests/TestAppUITests/AccountLoginTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountLoginTests.swift
@@ -53,9 +53,13 @@ final class AccountLoginTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["Login"].waitForExistence(timeout: 2))
         app.buttons["Login"].tap()
+        
+        XCTAssert(app.buttons["Email and Password"].waitForExistence(timeout: 2))
         app.buttons["Email and Password"].tap()
-        XCTAssertTrue(app.navigationBars.buttons["Login"].exists)
+        
+        XCTAssert(app.navigationBars.buttons["Login"].waitForExistence(timeout: 2))
         
         let usernameField = "Enter your email ..."
         let passwordField = "Enter your password ..."

--- a/Tests/UITests/TestAppUITests/AccountLoginTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountLoginTests.swift
@@ -15,9 +15,13 @@ final class AccountLoginTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["Login"].waitForExistence(timeout: 2))
         app.buttons["Login"].tap()
+        
+        XCTAssert(app.buttons["Username and Password"].waitForExistence(timeout: 2))
         app.buttons["Username and Password"].tap()
-        XCTAssertTrue(app.navigationBars.buttons["Login"].exists)
+        
+        XCTAssert(app.navigationBars.buttons["Login"].waitForExistence(timeout: 2))
         
         let usernameField = "Enter your username ..."
         let passwordField = "Enter your password ..."

--- a/Tests/UITests/TestAppUITests/AccountResetPasswordTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountResetPasswordTests.swift
@@ -15,10 +15,16 @@ final class AccountResetPasswordTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["Login"].waitForExistence(timeout: 2))
         app.buttons["Login"].tap()
+        
+        XCTAssert(app.buttons["Username and Password"].waitForExistence(timeout: 2))
         app.buttons["Username and Password"].tap()
+        
+        XCTAssert(app.buttons["Forgot Password?"].waitForExistence(timeout: 2))
         app.buttons["Forgot Password?"].tap()
-        XCTAssertTrue(app.navigationBars.buttons["Login"].exists)
+        
+        XCTAssert(app.navigationBars.buttons["Login"].waitForExistence(timeout: 2))
         
         let usernameField = "Enter your username ..."
         let username = "lelandstanford"

--- a/Tests/UITests/TestAppUITests/AccountResetPasswordTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountResetPasswordTests.swift
@@ -44,10 +44,16 @@ final class AccountResetPasswordTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["Login"].waitForExistence(timeout: 2))
         app.buttons["Login"].tap()
+        
+        XCTAssert(app.buttons["Email and Password"].waitForExistence(timeout: 2))
         app.buttons["Email and Password"].tap()
+        
+        XCTAssert(app.buttons["Forgot Password?"].waitForExistence(timeout: 2))
         app.buttons["Forgot Password?"].tap()
-        XCTAssertTrue(app.navigationBars.buttons["Login"].exists)
+        
+        XCTAssert(app.navigationBars.buttons["Login"].waitForExistence(timeout: 2))
         
         let usernameField = "Enter your email ..."
         let username = "lelandstanford@stanford.edu"

--- a/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
@@ -40,7 +40,10 @@ final class AccountSignUpTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["SignUp"].waitForExistence(timeout: 2))
         app.buttons["SignUp"].tap()
+        
+        XCTAssert(app.buttons["Email and Password"].waitForExistence(timeout: 2))
         app.buttons["Email and Password"].tap()
         
         let usernameField = "Enter your email ..."

--- a/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSignUpTests.swift
@@ -17,7 +17,10 @@ final class AccountSignUpTests: XCTestCase {
         let app = XCUIApplication()
         app.launch()
         
+        XCTAssert(app.buttons["SignUp"].waitForExistence(timeout: 2))
         app.buttons["SignUp"].tap()
+        
+        XCTAssert(app.buttons["Username and Password"].waitForExistence(timeout: 2))
         app.buttons["Username and Password"].tap()
         
         let usernameField = "Enter your username ..."

--- a/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
+++ b/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
@@ -10,7 +10,6 @@ import XCTest
 import XCTestExtensions
 
 final class EmptyAccountServicesTests: XCTestCase {
-
     func testDocumentationHint(forButton: String) throws {
         let app = XCUIApplication()
         app.launchArguments = ["--emptyAccountServices"]
@@ -19,11 +18,9 @@ final class EmptyAccountServicesTests: XCTestCase {
         app.buttons[forButton].tap()
 
         XCTAssertTrue(app.buttons["Open Documentation"].waitForExistence(timeout: 6))
-        XCTAssertTrue(
-            app
-                .staticTexts["No Account Services set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!"]
-                .waitForExistence(timeout: 6.0)
-        )
+
+        let text = "No Account Services set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!"
+        XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 6.0))
     }
 
     func testDocumentationHintLogin() throws {

--- a/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
+++ b/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+
+final class EmptyAccountServicesTests: XCTestCase {
+
+    func testDocumentationHint(forButton: String) throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--emptyAccountServices"]
+        app.launch()
+
+        app.buttons[forButton].tap()
+
+        XCTAssertTrue(app.buttons["Open Documentation"].waitForExistence(timeout: 6))
+        XCTAssertTrue(
+            app
+                .staticTexts["No Account Services set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!"]
+                .waitForExistence(timeout: 6.0)
+        )
+    }
+
+    func testDocumentationHintLogin() throws {
+        try testDocumentationHint(forButton: "Login")
+    }
+
+    func testDocumentationHintSignup() throws {
+        try testDocumentationHint(forButton: "SignUp")
+    }
+}

--- a/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
+++ b/Tests/UITests/TestAppUITests/EmptyAccountServicesTests.swift
@@ -17,10 +17,16 @@ final class EmptyAccountServicesTests: XCTestCase {
 
         app.buttons[forButton].tap()
 
-        XCTAssertTrue(app.buttons["Open Documentation"].waitForExistence(timeout: 6))
-
         let text = "No Account Services set up.\n Please refer to the documentation of the SpeziAccount package on how to set up an AccountService!"
         XCTAssertTrue(app.staticTexts[text].waitForExistence(timeout: 6.0))
+
+        XCTAssertTrue(app.buttons["Open Documentation"].waitForExistence(timeout: 6))
+        app.buttons["Open Documentation"].tap()
+
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        XCTAssert(safari.wait(for: .runningForeground, timeout: 10))
+
+        app.activate()
     }
 
     func testDocumentationHintLogin() throws {

--- a/Tests/UITests/TestAppUITests/XCUIApplication+TestPrimaryButton.swift
+++ b/Tests/UITests/TestAppUITests/XCUIApplication+TestPrimaryButton.swift
@@ -23,13 +23,7 @@ extension XCUIApplication {
         }
         
         if enabled {
-            guard !self.scrollViews.buttons["\(title), In progress"].waitForExistence(timeout: 1) else {
-                return
-            }
-            guard !self.collectionViews.buttons["\(title), In progress"].waitForExistence(timeout: 1) else {
-                return
-            }
-            XCTAssert(self.buttons["\(title), In progress"].waitForExistence(timeout: 1))
+            XCTAssert(self.activityIndicators.firstMatch.waitForExistence(timeout: 1))
         } else {
             XCTAssert(self.navigationBars.buttons[navigationBarButtonTitle].waitForExistence(timeout: 1))
             

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		2F027C9D29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C9C29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		A9EE7D282A3357D900C2B9A9 /* EmptyAccountServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D272A3357D900C2B9A9 /* EmptyAccountServicesTests.swift */; };
+		A9EE7D2A2A3359E800C2B9A9 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D292A3359E800C2B9A9 /* FeatureFlags.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +56,8 @@
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
+		A9EE7D272A3357D900C2B9A9 /* EmptyAccountServicesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyAccountServicesTests.swift; sourceTree = "<group>"; };
+		A9EE7D292A3359E800C2B9A9 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +118,7 @@
 			isa = PBXGroup;
 			children = (
 				2F027C9629D6C63300234098 /* AccountTests */,
+				A9EE7D292A3359E800C2B9A9 /* FeatureFlags.swift */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F027C9429D6C63100234098 /* TestAppDelegate.swift */,
 				2F027C9729D6C6DB00234098 /* TestAppStandard.swift */,
@@ -128,6 +133,7 @@
 				2F027C9C29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift */,
 				2F027C8C29D6C2CC00234098 /* AccountLoginTests.swift */,
 				2F027C8D29D6C2CC00234098 /* AccountResetPasswordTests.swift */,
+				A9EE7D272A3357D900C2B9A9 /* EmptyAccountServicesTests.swift */,
 				2F027C8E29D6C2CD00234098 /* AccountSignUpTests.swift */,
 			);
 			path = TestAppUITests;
@@ -253,6 +259,7 @@
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2F027C8B29D6C2AD00234098 /* MockUsernamePasswordAccountService.swift in Sources */,
 				2F027C8829D6C2AD00234098 /* MockAccountServiceError.swift in Sources */,
+				A9EE7D2A2A3359E800C2B9A9 /* FeatureFlags.swift in Sources */,
 				2F027C9529D6C63100234098 /* TestAppDelegate.swift in Sources */,
 				2F027C8929D6C2AD00234098 /* User.swift in Sources */,
 				2F027C9829D6C6DB00234098 /* TestAppStandard.swift in Sources */,
@@ -265,6 +272,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A9EE7D282A3357D900C2B9A9 /* EmptyAccountServicesTests.swift in Sources */,
 				2F027C9029D6C2CD00234098 /* AccountResetPasswordTests.swift in Sources */,
 				2F027C9D29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift in Sources */,
 				2F027C8F29D6C2CD00234098 /* AccountLoginTests.swift in Sources */,

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -16,13 +16,13 @@
 		2F027C8F29D6C2CD00234098 /* AccountLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C8C29D6C2CC00234098 /* AccountLoginTests.swift */; };
 		2F027C9029D6C2CD00234098 /* AccountResetPasswordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C8D29D6C2CC00234098 /* AccountResetPasswordTests.swift */; };
 		2F027C9129D6C2CD00234098 /* AccountSignUpTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C8E29D6C2CD00234098 /* AccountSignUpTests.swift */; };
-		2F027C9329D6C43500234098 /* SpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2F027C9229D6C43500234098 /* SpeziAccount */; };
 		2F027C9529D6C63100234098 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C9429D6C63100234098 /* TestAppDelegate.swift */; };
 		2F027C9829D6C6DB00234098 /* TestAppStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C9729D6C6DB00234098 /* TestAppStandard.swift */; };
 		2F027C9B29D6C91E00234098 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2F027C9A29D6C91E00234098 /* XCTestExtensions */; };
 		2F027C9D29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F027C9C29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		2FAD38C02A455FC200E79ED1 /* SpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FAD38BF2A455FC200E79ED1 /* SpeziAccount */; };
 		A9EE7D282A3357D900C2B9A9 /* EmptyAccountServicesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D272A3357D900C2B9A9 /* EmptyAccountServicesTests.swift */; };
 		A9EE7D2A2A3359E800C2B9A9 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D292A3359E800C2B9A9 /* FeatureFlags.swift */; };
 /* End PBXBuildFile section */
@@ -50,11 +50,11 @@
 		2F027C9429D6C63100234098 /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		2F027C9729D6C6DB00234098 /* TestAppStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppStandard.swift; sourceTree = "<group>"; };
 		2F027C9C29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+TestPrimaryButton.swift"; sourceTree = "<group>"; };
-		2F68C3C6292E9F8F00B3E12C /* SpeziAccount */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziAccount; path = ../..; sourceTree = "<group>"; };
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		2FAD38BE2A455F7D00E79ED1 /* SpeziAccount */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = SpeziAccount; path = ../..; sourceTree = "<group>"; };
 		2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 		A9EE7D272A3357D900C2B9A9 /* EmptyAccountServicesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmptyAccountServicesTests.swift; sourceTree = "<group>"; };
 		A9EE7D292A3359E800C2B9A9 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
@@ -65,7 +65,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2F027C9329D6C43500234098 /* SpeziAccount in Frameworks */,
+				2FAD38C02A455FC200E79ED1 /* SpeziAccount in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				2FB0758A299DDB9000C0B37F /* TestApp.xctestplan */,
-				2F68C3C6292E9F8F00B3E12C /* SpeziAccount */,
+				2FAD38BE2A455F7D00E79ED1 /* SpeziAccount */,
 				2F6D139428F5F384007C25D6 /* TestApp */,
 				2F6D13AF28F5F386007C25D6 /* TestAppUITests */,
 				2F6D139328F5F384007C25D6 /* Products */,
@@ -163,7 +163,7 @@
 			);
 			name = TestApp;
 			packageProductDependencies = (
-				2F027C9229D6C43500234098 /* SpeziAccount */,
+				2FAD38BF2A455FC200E79ED1 /* SpeziAccount */,
 			);
 			productName = Example;
 			productReference = 2F6D139228F5F384007C25D6 /* TestApp.app */;
@@ -667,14 +667,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		2F027C9229D6C43500234098 /* SpeziAccount */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SpeziAccount;
-		};
 		2F027C9A29D6C91E00234098 /* XCTestExtensions */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2F027C9929D6C91D00234098 /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
 			productName = XCTestExtensions;
+		};
+		2FAD38BF2A455FC200E79ED1 /* SpeziAccount */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SpeziAccount;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -661,7 +661,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.1;
+				minimumVersion = 0.4.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpeziAccount"
+               BuildableName = "SpeziAccount"
+               BlueprintName = "SpeziAccount"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -8,20 +8,6 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
-               BuildableName = "TestApp.app"
-               BlueprintName = "TestApp"
-               ReferencedContainer = "container:UITests.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
@@ -32,6 +18,20 @@
                BuildableName = "SpeziAccount"
                BlueprintName = "SpeziAccount"
                ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>


### PR DESCRIPTION
# Show a message when no account services are set up

## :recycle: Current situation & Problem
Currently, when there are no `AccountService`s set up the `AcountServicesView` just displays nothing instead of the button. Especially for developers new to the framework ecosystem, they might be unfamiliar that AccountServices are set up globally and that the respective Signup/Login buttons are place automatically.

## :bulb: Proposed solution
This PR tries to avoid this problem by giving a visual hint on why no `AccountServiceButton`s are shown. 

## :gear: Release Notes 
* Improved diagnostics when no `AccountService`s are set up.

## :heavy_plus_sign: Additional Information

@PSchmiedmayer We might consider an alternative where we don't display the diagnostic message but only print the message to the app logger. Are there any guidelines on how to deal with (configuration) issues like these in the Spezi framework ecosystem?

Additionally, the PR fixes some missing translations and misspelled translations in previews.

### Related PRs
--

### Testing
This case is currently not covered in the UI tests.

### Reviewer Nudging
All the primary changes happen in the `AccountServicesView`.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

### Attachments 

<img width="466" alt="Bildschirmfoto 2023-06-17 um 16 07 48" src="https://github.com/StanfordSpezi/SpeziAccount/assets/9783857/e75dc87c-647d-4fee-9771-cb6a21f6ae61">
