### PR TITLE
Make VerifiableTextGridRow Public & Improve API Surface

### DIFF
--- a/Sources/SpeziAccount/Username and Password/Shared/ValidationRule.swift
+++ b/Sources/SpeziAccount/Username and Password/Shared/ValidationRule.swift
@@ -61,7 +61,7 @@ public struct ValidationRule: Decodable {
     }
     
     /// Validates the contents of a `String` and returns a `String` error message if validation fails
-    func validate(_ input: String) -> String? {
+    public func validate(_ input: String) -> String? {
         guard !rule(input) else {
             return nil
         }

--- a/Sources/SpeziAccount/Views/VerifiableTextGridRow.swift
+++ b/Sources/SpeziAccount/Views/VerifiableTextGridRow.swift
@@ -10,7 +10,8 @@ import SpeziViews
 import SwiftUI
 
 
-struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
+/// A reusable view to enable building verifiable text fields.
+public struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
     private let description: Description
     private let textField: TextField
     private let validationRules: [ValidationRule]
@@ -26,7 +27,7 @@ struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
     @State private var validationResults: [String] = []
     
     
-    var body: some View {
+    public var body: some View {
         DescriptionGridRow {
             description
         } content: {
@@ -56,7 +57,13 @@ struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
     }
     
     
-    init(
+    /// - Parameters:
+    ///   - text: The text that is displayed in the text field.
+    ///   - valid: If the text is valid in accordance to the validation rules.
+    ///   - validationRules: The validation rules that are applied.
+    ///   - description: The description of the text field.
+    ///   - textField: The text field that is verified.
+    public init(
         text: Binding<String>,
         valid: Binding<Bool>,
         validationRules: [ValidationRule] = [],
@@ -70,9 +77,13 @@ struct VerifiableTextFieldGridRow<Description: View, TextField: View>: View {
         self.textField = textField(text)
     }
     
-    // We want to have the same argument order as found in the main initializer. We do not move the description property up as it constructs a trailing closure in the main initializer.
-    // swiftlint:disable:next function_default_parameter_at_end
-    init(
+    /// - Parameters:
+    ///   - text: The text that is displayed in the text field.
+    ///   - valid: If the text is valid in accordance to the validation rules.
+    ///   - validationRules: The validation rules that are applied.
+    ///   - description: The description of the text field.
+    ///   - textField: The text field that is verified.
+    public init( // swiftlint:disable:this function_default_parameter_at_end
         text: Binding<String>,
         valid: Binding<Bool>,
         validationRules: [ValidationRule] = [],


### PR DESCRIPTION
# Make VerifiableTextGridRow Public & Improve API Surface

## :recycle: Current situation & Problem
- Make a few APIs public before we jump to 0.5.0 to ensure that we can use verifiable text grid row in a few different projects before the new verifiable textfields will be tagged with 0.5.0


## :gear: Release Notes 
- Make `VerifiableTextGridRow` public and improve the 0.4.X API surface


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
