### PR TITLE
Remove NavigationStacks from Setup and Overview and display SignupForm as a sheet

### DIFF
--- a/Sources/SpeziAccount/AccountConfiguration.swift
+++ b/Sources/SpeziAccount/AccountConfiguration.swift
@@ -90,9 +90,7 @@ public final class AccountConfiguration: Component, ObservableObjectProvider {
             configuration: configuredAccountKeys
         )
 
-        if let accountStandard = standard as? any AccountStorageStandard {
-            self.account?.injectWeakAccount(into: accountStandard)
-        }
+        self.account?.injectWeakAccount(into: standard)
     }
 
     private func verifyAccountServiceRequirements(of service: any AccountService) {

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -41,7 +41,7 @@ public struct AccountOverview: View {
     @Binding private var isEditing: Bool
 
     public var body: some View {
-        NavigationStack {
+        VStack {
             if let details = account.details {
                 Form {
                     // Splitting everything into a separate subview was actually necessary for the EditMode to work.
@@ -83,11 +83,15 @@ struct AccountOverView_Previews: PreviewProvider {
         .set(\.genderIdentity, value: .male)
 
     static var previews: some View {
-        AccountOverview()
-            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+        NavigationStack {
+            AccountOverview()
+                .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+        }
 
-        AccountOverview()
-            .environmentObject(Account())
+        NavigationStack {
+            AccountOverview()
+                .environmentObject(Account())
+        }
     }
 }
 #endif

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -88,13 +88,13 @@ struct AccountOverView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             AccountOverview()
-                .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
         }
+            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
 
         NavigationStack {
             AccountOverview()
-                .environmentObject(Account())
         }
+            .environmentObject(Account())
     }
 }
 #endif

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -15,6 +15,9 @@ import SwiftUI
 /// This provides an overview of the current account details. Further, it allows the user to modify their
 /// account values.
 ///
+/// - Important: This view requires to be placed inside a [NavigationStack](https://developer.apple.com/documentation/swiftui/navigationstack/)
+///     to work properly.
+///
 /// This view requires a currently logged in user (see ``Account/details``).
 /// Further, this view relies on an ``Account`` object in its environment. This is done automatically by providing a
 /// ``AccountConfiguration`` in the configuration section of your `Spezi` app delegate.

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -193,32 +193,24 @@ struct AccountView_Previews: PreviewProvider {
 
     @MainActor static var previews: some View {
         ForEach(accountServicePermutations.indices, id: \.self) { index in
-            NavigationStack {
-                AccountSetup()
-            }
+            AccountSetup()
                 .environmentObject(Account(services: accountServicePermutations[index] + [MockSignInWithAppleProvider()]))
         }
 
-        NavigationStack {
-            AccountSetup()
-        }
+        AccountSetup()
             .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
 
-        NavigationStack {
-            AccountSetup(state: .setupShown)
-        }
+        AccountSetup(state: .setupShown)
             .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
 
-        NavigationStack {
-            AccountSetup {
-                Button(action: {
-                    print("Continue")
-                }, label: {
-                    Text("Continue")
-                        .frame(maxWidth: .infinity, minHeight: 38)
-                })
+        AccountSetup {
+            Button(action: {
+                print("Continue")
+            }, label: {
+                Text("Continue")
+                    .frame(maxWidth: .infinity, minHeight: 38)
+            })
                 .buttonStyle(.borderedProminent)
-            }
         }
             .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
     }

--- a/Sources/SpeziAccount/AccountStorageStandard.swift
+++ b/Sources/SpeziAccount/AccountStorageStandard.swift
@@ -78,8 +78,8 @@ public protocol AccountStorageStandard: Standard {
 }
 
 
-extension AccountStorageStandard {
-    /// A property wrapper that can be used within ``AccountStorageStandard`` instances to request
+extension Standard {
+    /// A property wrapper that can be used within `Standard` instances to request
     /// access to the global ``Account`` instance.
     ///
     /// Below is a short code example on how to use this property wrapper:

--- a/Sources/SpeziAccount/AccountValue/Keys/PersonNameKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/PersonNameKey.swift
@@ -47,10 +47,9 @@ extension PersonNameKey {
         private let value: PersonNameComponents
 
         public var body: some View {
-            Text(Key.name)
-            Spacer()
-            Text(value.formatted(.name(style: .long)))
-                .foregroundColor(.secondary)
+            SimpleTextRow(name: Key.name) {
+                Text(value.formatted(.name(style: .long)))
+            }
         }
 
 

--- a/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 "UP_CONTACT_DETAILS" = "Kontaktdaten";
 "UP_PERSONAL_DETAILS" = "Persönliche Details";
 "UP_SIGNUP_FAILED_DEFAULT_ERROR" = "Registrierung fehlgeschlagen!";
+"CLOSE" = "Schließen";
 
 // MARK: - UserId and Password (Password Reset)
 "UP_RESET_PASSWORD" = "Passwort Zurücksetzten";
@@ -58,12 +59,6 @@
 
 // MARK - Account Overview
 "ACCOUNT_OVERVIEW" = "Benutzerkonto";
-"CONFIRMATION_DISCARD_CHANGES_TITLE" = "Willst du alle Änderungen verwerfen?";
-"CONFIRMATION_DISCARD_CHANGES" = "Änderungen Verwerfen";
-"CONFIRMATION_KEEP_EDITING"= "Weiter Bearbeiten";
-"CONFIRMATION_LOGOUT" = "Willst du dich wirklich abmelden?";
-"CONFIRMATION_REMOVAL" = "Willst du wirklich dein Benutzerkonto löschen?";
-"CONFIRMATION_REMOVAL_SUGGESTION" = "Dieser Vorgang is endgültig und du kannst dein Konto Informationen nicht wiederherstellen.";
 "DELETE_ACCOUNT" = "Löschen";
 "DONE" = "Fertig";
 "EDIT" = "Bearbeiten";
@@ -74,6 +69,16 @@
 "SECURITY" = "Sicherheit";
 "VALUE_ADD %@" = "%@ Hinzufügen";
 "CHANGE_PASSWORD" = "Passwort Ändern";
+
+// MARK - Confirmation Dialogs
+"CONFIRMATION_DISCARD_CHANGES_TITLE" = "Willst du alle Änderungen verwerfen?";
+"CONFIRMATION_DISCARD_INPUT_TITLE" = "Willst du deine Eingaben verwerfen?";
+"CONFIRMATION_DISCARD_CHANGES" = "Änderungen Verwerfen";
+"CONFIRMATION_DISCARD_INPUT" = "Eingaben Verwerfen";
+"CONFIRMATION_KEEP_EDITING"= "Weiter Bearbeiten";
+"CONFIRMATION_LOGOUT" = "Willst du dich wirklich abmelden?";
+"CONFIRMATION_REMOVAL" = "Willst du wirklich dein Benutzerkonto löschen?";
+"CONFIRMATION_REMOVAL_SUGGESTION" = "Dieser Vorgang is endgültig und du kannst dein Konto Informationen nicht wiederherstellen.";
 
 // MARK: - Validation Rules
 "VALIDATION_RULE_NON_EMPTY" = "Diese Feld kann nicht leer sein.";

--- a/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 "UP_CONTACT_DETAILS" = "Contact Details";
 "UP_PERSONAL_DETAILS" = "Personal Details";
 "UP_SIGNUP_FAILED_DEFAULT_ERROR" = "Could not sign up!";
+"CLOSE" = "Close";
 
 // MARK: - UserId and Password (Password Reset)
 "UP_RESET_PASSWORD" = "Reset Password";
@@ -58,12 +59,6 @@
 
 // MARK - Account Overview
 "ACCOUNT_OVERVIEW" = "Account Overview";
-"CONFIRMATION_DISCARD_CHANGES_TITLE" = "Are you sure you want to discard your changes?";
-"CONFIRMATION_DISCARD_CHANGES" = "Discard Changes";
-"CONFIRMATION_KEEP_EDITING"= "Keep Editing";
-"CONFIRMATION_LOGOUT" = "Are you sure you want to logout?";
-"CONFIRMATION_REMOVAL" = "Are you sure you want to delete your account?";
-"CONFIRMATION_REMOVAL_SUGGESTION" = "This change is permanent and you won't be able to recover your account information.";
 "DELETE_ACCOUNT" = "Delete Account";
 "DONE" = "Done";
 "EDIT" = "Edit";
@@ -74,6 +69,16 @@
 "SECURITY" = "Security";
 "VALUE_ADD %@" = "Add %@";
 "CHANGE_PASSWORD" = "Change Password";
+
+// MARK - Confirmation Dialogs
+"CONFIRMATION_DISCARD_CHANGES_TITLE" = "Are you sure you want to discard your changes?";
+"CONFIRMATION_DISCARD_INPUT_TITLE" = "Are you sure you want to discard your input?";
+"CONFIRMATION_DISCARD_CHANGES" = "Discard Changes";
+"CONFIRMATION_DISCARD_INPUT" = "Discard Input";
+"CONFIRMATION_KEEP_EDITING"= "Keep Editing";
+"CONFIRMATION_LOGOUT" = "Are you sure you want to logout?";
+"CONFIRMATION_REMOVAL" = "Are you sure you want to delete your account?";
+"CONFIRMATION_REMOVAL_SUGGESTION" = "This change is permanent and you won't be able to recover your account information.";
 
 // MARK: - Validation Rules
 "VALIDATION_RULE_NON_EMPTY" = "This field cannot be empty.";

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyEditRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyEditRow.swift
@@ -76,3 +76,24 @@ struct AccountKeyEditRow: View {
         return !model.addedAccountKeys.contains(key)
     }
 }
+
+#if DEBUG
+struct AccountKeyEditRow_Previews: PreviewProvider {
+    static let details = AccountDetails.Builder()
+        .set(\.userId, value: "andi.bauer@tum.de")
+        .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
+        .set(\.genderIdentity, value: .male)
+
+    static let account = Account(building: details, active: MockUserIdPasswordAccountService())
+
+    @StateObject private static var model = AccountOverviewFormViewModel(account: account)
+    @FocusState private static var focusedDataEntry: String?
+
+    static var previews: some View {
+        if let details = account.details {
+            AccountKeyEditRow(details: details, for: GenderIdentityKey.self, model: model)
+                .injectEnvironmentObjects(service: details.accountService, model: model, focusState: $focusedDataEntry)
+        }
+    }
+}
+#endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -246,7 +246,7 @@ struct AccountOverviewSections_Previews: PreviewProvider {
         NavigationStack {
             AccountOverview()
         }
-        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -49,7 +49,7 @@ struct AccountOverviewSections: View {
             .viewStateAlert(state: $destructiveViewState)
             .toolbar {
                 if editMode?.wrappedValue.isEditing == true && !isProcessing {
-                    ToolbarItemGroup(placement: .cancellationAction) {
+                    ToolbarItem(placement: .cancellationAction) {
                         Button(action: {
                             model.cancelEditAction(editMode: editMode)
                         }) {
@@ -58,7 +58,7 @@ struct AccountOverviewSections: View {
                     }
                 }
                 if destructiveViewState == .idle {
-                    ToolbarItemGroup(placement: .primaryAction) {
+                    ToolbarItem(placement: .primaryAction) {
                         AsyncButton(state: $viewState, action: editButtonAction) {
                             if editMode?.wrappedValue.isEditing == true {
                                 Text("DONE", bundle: .module)

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -88,7 +88,7 @@ struct NameOverview_Previews: PreviewProvider {
             .environmentObject(account)
 
         NavigationStack {
-            if let details = account.details {
+            if let details = accountWithoutName.details {
                 NameOverview(model: model, details: details)
             }
         }

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -45,12 +45,12 @@ struct PasswordChangeSheet: View {
                 .navigationTitle(Text("CHANGE_PASSWORD", bundle: .module))
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
-                    ToolbarItemGroup(placement: .primaryAction) {
+                    ToolbarItem(placement: .primaryAction) {
                         AsyncButton(state: $viewState, action: submitPasswordChange) {
                             Text("DONE", bundle: .module)
                         }
                     }
-                    ToolbarItemGroup(placement: .cancellationAction) {
+                    ToolbarItem(placement: .cancellationAction) {
                         Button(action: {
                             dismiss()
                         }) {

--- a/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
@@ -15,6 +15,7 @@ import SwiftUI
 /// present the appropriate subtitle.
 public struct DefaultAccountSetupHeader: View {
     @EnvironmentObject private var account: Account
+    @Environment(\._accountSetupState) private var setupState
 
     public var body: some View {
         VStack {
@@ -26,7 +27,7 @@ public struct DefaultAccountSetupHeader: View {
                 .padding(.top, 30)
 
             Group {
-                if !account.signedIn {
+                if !account.signedIn || setupState == .loadingExistingAccount {
                     Text("ACCOUNT_WELCOME_SUBTITLE", bundle: .module)
                 } else {
                     Text("ACCOUNT_WELCOME_SIGNED_IN_SUBTITLE", bundle: .module)

--- a/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
@@ -35,7 +35,7 @@ struct ExistingAccountView<Continue: View>: View {
         }
             .viewStateAlert(state: $viewState)
             .toolbar {
-                ToolbarItemGroup(placement: .bottomBar) {
+                ToolbarItem(placement: .bottomBar) {
                     if Continue.self != EmptyView.self {
                         VStack {
                             continueButton

--- a/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
@@ -40,6 +40,7 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
     @StateObject private var userIdValidation = ValidationEngine(rules: [.nonEmpty], configuration: .hideFailedValidationOnEmptySubmit)
     @StateObject private var passwordValidation = ValidationEngine(rules: [.nonEmpty], configuration: .hideFailedValidationOnEmptySubmit)
 
+    @State private var presentingSignupSheet = false
     @State private var presentingPasswordForgetSheet = false
 
     @State private var loginTask: Task<Void, Error>? {
@@ -67,9 +68,9 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
 
             HStack {
                 Text("UP_NO_ACCOUNT_YET", bundle: .module)
-                NavigationLink {
-                    service.viewStyle.makeSignupView()
-                } label: {
+                Button(action: {
+                    presentingSignupSheet = true
+                }) {
                     Text("UP_SIGNUP", bundle: .module)
                 }
             }
@@ -77,6 +78,11 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
         }
             .disableDismissiveActions(isProcessing: state)
             .viewStateAlert(state: $state)
+            .sheet(isPresented: $presentingSignupSheet) {
+                NavigationStack {
+                    service.viewStyle.makeSignupView()
+                }
+            }
             .sheet(isPresented: $presentingPasswordForgetSheet) {
                 NavigationStack {
                     service.viewStyle.makePasswordResetView()
@@ -155,8 +161,8 @@ struct DefaultUserIdPasswordBasedEmbeddedView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             UserIdPasswordEmbeddedView(using: accountService)
-                .environmentObject(Account(accountService))
         }
+            .environmentObject(Account(accountService))
     }
 }
 #endif

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -80,7 +80,7 @@ struct AccountTestsView: View {
     @ToolbarContentBuilder
     func toolbar(closing flag: Binding<Bool>) -> some ToolbarContent {
         if !isEditing {
-            ToolbarItemGroup(placement: .cancellationAction) {
+            ToolbarItem(placement: .cancellationAction) {
                 Button("Close") {
                     flag.wrappedValue = false
                 }

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -27,11 +27,9 @@ final class AccountOverviewTests: XCTestCase {
         overview.verifyExistence(text: "Name, E-Mail Address")
         overview.verifyExistence(text: "Password & Security")
 
-        overview.verifyExistence(text: "Gender Identity")
-        overview.verifyExistence(text: "Male")
+        overview.verifyExistence(text: "Gender Identity, Male")
 
-        overview.verifyExistence(text: "Date of Birth")
-        overview.verifyExistence(text: "Mar 9, 1824")
+        overview.verifyExistence(text: "Date of Birth, Mar 9, 1824")
 
         XCTAssertTrue(overview.buttons["Logout"].waitForExistence(timeout: 0.5))
     }

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -143,16 +143,16 @@ final class AccountSetupTests: XCTestCase {
         var signupView = setup.openSignup()
 
         // verify basic validation
-        XCTAssertTrue(signupView.buttons["Signup"].exists)
-        XCTAssertTrue(!signupView.buttons["Signup"].isEnabled)
+        XCTAssertTrue(signupView.collectionViews.buttons["Signup"].exists)
+        XCTAssertTrue(!signupView.collectionViews.buttons["Signup"].isEnabled)
         XCTAssertFalse(signupView.staticTexts["This field cannot be empty."].exists)
 
         // verify empty validation appearing
-        try signupView.textFields["E-Mail Address"].enter(value: "a", dismissKeyboard: false)
+        try signupView.collectionViews.textFields["E-Mail Address"].enter(value: "a", dismissKeyboard: false)
         signupView.app.typeText(XCUIKeyboardKey.delete.rawValue) // we have remaining focus
         signupView.app.dismissKeyboard()
 
-        try signupView.secureTextFields["Password"].enter(value: "a", dismissKeyboard: false)
+        try signupView.collectionViews.secureTextFields["Password"].enter(value: "a", dismissKeyboard: false)
         signupView.app.typeText(XCUIKeyboardKey.delete.rawValue) // we have remaining focus
         signupView.app.dismissKeyboard()
 
@@ -160,17 +160,17 @@ final class AccountSetupTests: XCTestCase {
         XCTAssertEqual(signupView.staticTexts.matching(identifier: "This field cannot be empty.").count, 2)
 
         // not sure why, but text-field selection has issues due to the presented validation messages, so we exit a reenter to resolve this
-        setup = signupView.tapBack()
+        setup = signupView.tapClose()
         signupView = setup.openSignup()
 
         // enter email with validation
-        try signupView.textFields["E-Mail Address"].enter(value: String(email.dropLast(13)), dismissKeyboard: false)
+        try signupView.collectionViews.textFields["E-Mail Address"].enter(value: String(email.dropLast(13)), dismissKeyboard: false)
         XCTAssertTrue(signupView.staticTexts["The provided email is invalid."].waitForExistence(timeout: 2.0))
         signupView.app.typeText(String(email.dropFirst(13))) // we stay focused
         signupView.app.dismissKeyboard()
 
         // enter password with validation
-        try signupView.secureTextFields["Password"].enter(value: String(password.dropLast(5)), dismissKeyboard: false)
+        try signupView.collectionViews.secureTextFields["Password"].enter(value: String(password.dropLast(5)), dismissKeyboard: false)
         XCTAssertTrue(signupView.staticTexts["Your password must be at least 8 characters long."].waitForExistence(timeout: 2.0))
         signupView.app.typeText(String(password.dropFirst(4))) // stay focused, such that password field will not reset after regaining focus
         signupView.app.dismissKeyboard()
@@ -193,8 +193,8 @@ final class AccountSetupTests: XCTestCase {
             .openAccountSetup()
             .openSignup(sleep: 3)
 
-        XCTAssertTrue(signupView.buttons["Signup"].exists)
-        XCTAssertFalse(signupView.buttons["Signup"].isEnabled)
+        XCTAssertTrue(signupView.collectionViews.buttons["Signup"].exists)
+        XCTAssertFalse(signupView.collectionViews.buttons["Signup"].isEnabled)
 
         try signupView.enter(field: "enter first name", text: "a")
         try signupView.delete(field: "enter first name", count: 1)
@@ -246,8 +246,7 @@ final class AccountSetupTests: XCTestCase {
         overview.verifyExistence(text: "LS")
         overview.verifyExistence(text: "Leland Stanford")
         overview.verifyExistence(text: "lelandstanford2@stanford.edu")
-        overview.verifyExistence(text: "Gender Identity")
-        overview.verifyExistence(text: "Male")
+        overview.verifyExistence(text: "Gender Identity, Male")
         overview.verifyExistence(text: "Date of Birth")
     }
 
@@ -275,10 +274,8 @@ final class AccountSetupTests: XCTestCase {
 
         let email = "lelandstanford2@stanford.edu"
 
-        try signupView.enter(field: "E-Mail Address", text: email)
-        try signupView.enter(secureField: "Password", text: "123456789")
-
-        try signupView.enter(field: "enter first name", text: "Leland")
+        try signupView.fillForm(email: email, password: "123456789", name: PersonNameComponents(givenName: "Leland"))
+        
         try signupView.delete(field: "enter first name", count: 6)
 
         signupView.signup(sleep: 3)

--- a/Tests/UITests/TestAppUITests/DocumentationHintsTests.swift
+++ b/Tests/UITests/TestAppUITests/DocumentationHintsTests.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Spezi open-source project
 //
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //

--- a/Tests/UITests/TestAppUITests/Utils/SignupView.swift
+++ b/Tests/UITests/TestAppUITests/Utils/SignupView.swift
@@ -27,9 +27,12 @@ struct SignupView: AccountValueView {
         genderIdentity: String? = nil,
         supplyDateOfBirth: Bool = false
     ) throws {
-        try enter(field: "E-Mail Address", text: email)
+        // we access through collectionViews as there is another E-Mail Address and Password field behind the signup sheet
+        XCTAssertTrue(app.collectionViews.textFields["E-Mail Address"].waitForExistence(timeout: 1.0))
+        try app.collectionViews.textFields["E-Mail Address"].enter(value: email)
 
-        try enter(secureField: "Password", text: password)
+        XCTAssertTrue(app.collectionViews.secureTextFields["Password"].waitForExistence(timeout: 1.0))
+        try app.collectionViews.secureTextFields["Password"].enter(value: password)
 
         if let name {
             if let firstname = name.givenName {
@@ -50,15 +53,22 @@ struct SignupView: AccountValueView {
     }
 
     func signup(sleep sleepMillis: UInt32 = 0) {
-        tap(button: "Signup")
+        // we access the signup button through the collectionView as there is another signup button behind the signup sheet.
+        XCTAssertTrue(app.collectionViews.buttons["Signup"].waitForExistence(timeout: 1.0))
+        app.collectionViews.buttons["Signup"].tap()
+
         if sleepMillis > 0 {
             sleep(sleepMillis)
         }
     }
 
-    func tapBack(timeout: TimeInterval = 1.0) -> TestableAccountSetup {
-        XCTAssertTrue(app.navigationBars.buttons["Back"].waitForExistence(timeout: timeout))
-        app.navigationBars.buttons["Back"].tap()
+    func tapClose(timeout: TimeInterval = 1.0, discardChangesIfAsked: Bool = true) -> TestableAccountSetup {
+        XCTAssertTrue(app.navigationBars["Signup"].buttons["Close"].waitForExistence(timeout: timeout))
+        app.navigationBars["Signup"].buttons["Close"].tap()
+
+        if discardChangesIfAsked && app.staticTexts["Are you sure you want to discard your input?"].waitForExistence(timeout: 2.0) {
+            tap(button: "Discard Input")
+        }
 
         let setup = TestableAccountSetup(app: app)
         setup.verify()


### PR DESCRIPTION
# Remove NavigationStacks from Setup and Overview and display SignupForm as a sheet

## :recycle: Current situation & Problem
Currently, we automatically place a `NavigationStack` in the `AccountSetup` and `AccountOverview` views which causes due to nested NavigationStacks like in https://github.com/StanfordSpezi/SpeziOnboarding/issues/21.

This PR removes the NavigationStack dependence from the `AccountSetup` view by presenting the `SignupForm` as a sheet. Further, the `AccountOverview` now requires to be placed into a NavigationStack and doesn't automatically create one by itself.

## :gear: Release Notes 
* `AccountSetup` doesn't use a NavigationStack anymore by presenting the `SignupForm` as a sheet.
* The `AccountSetup` doesn't place itself automatically in a NavigationStack anymore and thus requires one to be present in the view hierarchy already.

## :books: Documentation
Documentation was updated to reflect those new requirements.


## :white_check_mark: Testing
Tests were updated and adjusted.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
