### PR TITLE
Introduce the AccountNotifyStandard

### DIFF
--- a/Sources/SpeziAccount/AccountConfiguration.swift
+++ b/Sources/SpeziAccount/AccountConfiguration.swift
@@ -82,7 +82,13 @@ public final class AccountConfiguration: Component, ObservableObjectProvider {
 
             // Verify account service can store all configured account keys.
             // If applicable, wraps the service into an StandardBackedAccountService
-            return verifyConfigurationRequirements(against: service)
+            let service = verifyConfigurationRequirements(against: service)
+
+            if let notifyStandard = standard as? any AccountNotifyStandard {
+                return service.backedBy(standard: notifyStandard)
+            }
+
+            return service
         }
 
         self.account = Account(

--- a/Sources/SpeziAccount/AccountNotifyStandard.swift
+++ b/Sources/SpeziAccount/AccountNotifyStandard.swift
@@ -1,0 +1,18 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+
+
+/// A `Spezi` Standard that allows to react to certain Account-based events.
+public protocol AccountNotifyStandard: Standard {
+    /// Notifies the Standard that the associated account was requested to be deleted by the user.
+    ///
+    /// Use this method to cleanup any account related data that might be associated with the account.
+    func deletedAccount() async
+}

--- a/Sources/SpeziAccount/AccountNotifyStandard.swift
+++ b/Sources/SpeziAccount/AccountNotifyStandard.swift
@@ -14,5 +14,5 @@ public protocol AccountNotifyStandard: Standard {
     /// Notifies the Standard that the associated account was requested to be deleted by the user.
     ///
     /// Use this method to cleanup any account related data that might be associated with the account.
-    func deletedAccount() async
+    func deletedAccount() async throws
 }

--- a/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
@@ -1,0 +1,37 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+
+
+actor NotifyStandardBackedAccountService<Service: AccountService, Standard: AccountNotifyStandard>: AccountService, StandardBacked {
+    @AccountReference private var account
+
+    let accountService: Service
+    let standard: Standard
+    
+    nonisolated var configuration: AccountServiceConfiguration {
+        accountService.configuration
+    }
+
+    nonisolated var viewStyle: Service.ViewStyle {
+        accountService.viewStyle
+    }
+
+
+    init(service accountService: Service, standard: Standard) {
+        self.accountService = accountService
+        self.standard = standard
+    }
+
+
+    func delete() async throws {
+        try await accountService.delete()
+        await standard.deletedAccount()
+    }
+}

--- a/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
@@ -40,3 +40,5 @@ actor NotifyStandardBackedAccountService<Service: AccountService, Standard: Acco
 extension NotifyStandardBackedAccountService: EmbeddableAccountService where Service: EmbeddableAccountService {}
 
 extension NotifyStandardBackedAccountService: UserIdPasswordAccountService where Service: UserIdPasswordAccountService {}
+
+extension NotifyStandardBackedAccountService: IdentityProvider where Service: IdentityProvider {}

--- a/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
@@ -31,8 +31,8 @@ actor NotifyStandardBackedAccountService<Service: AccountService, Standard: Acco
 
 
     func delete() async throws {
+        try await standard.deletedAccount()
         try await accountService.delete()
-        await standard.deletedAccount()
     }
 }
 

--- a/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
@@ -35,3 +35,8 @@ actor NotifyStandardBackedAccountService<Service: AccountService, Standard: Acco
         await standard.deletedAccount()
     }
 }
+
+
+extension NotifyStandardBackedAccountService: EmbeddableAccountService where Service: EmbeddableAccountService {}
+
+extension NotifyStandardBackedAccountService: UserIdPasswordAccountService where Service: UserIdPasswordAccountService {}

--- a/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
@@ -61,6 +61,17 @@ extension StandardBacked {
 }
 
 
+extension StandardBacked where Self: UserIdPasswordAccountService, Service: UserIdPasswordAccountService {
+    func login(userId: String, password: String) async throws {
+        try await accountService.login(userId: userId, password: password)
+    }
+
+    func resetPassword(userId: String) async throws {
+        try await accountService.resetPassword(userId: userId)
+    }
+}
+
+
 extension AccountService {
     func backedBy(standard: any AccountStorageStandard) -> any AccountService {
         standard.backedService(with: self)

--- a/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
@@ -1,0 +1,86 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+
+
+/// Internal marker protocol to determine what ``AccountService`` require assistance by a ``AccountStorageStandard``.
+protocol StandardBacked: AccountService {
+    associatedtype Service: AccountService
+    associatedtype AccountStandard: Standard
+
+    var accountService: Service { get }
+    var standard: AccountStandard { get }
+
+    init(service: Service, standard: AccountStandard)
+
+    func isBacking(service accountService: any AccountService) -> Bool
+}
+
+
+extension StandardBacked {
+    var backedId: String {
+        if let nestedBacked = accountService as? any StandardBacked {
+            return nestedBacked.backedId
+        }
+
+        return accountService.id
+    }
+
+
+    func isBacking(service: any AccountService) -> Bool {
+        if let nestedBacked = self.accountService as? any StandardBacked {
+            return nestedBacked.isBacking(service: service)
+        }
+        return self.accountService.objId == service.objId
+    }
+}
+
+
+extension StandardBacked {
+    func signUp(signupDetails: SignupDetails) async throws {
+        try await accountService.signUp(signupDetails: signupDetails)
+    }
+
+    func logout() async throws {
+        try await accountService.logout()
+    }
+
+    func delete() async throws {
+        try await accountService.delete()
+    }
+
+    func updateAccountDetails(_ modifications: AccountModifications) async throws {
+        try await accountService.updateAccountDetails(modifications)
+    }
+}
+
+
+extension AccountService {
+    func backedBy(standard: any AccountStorageStandard) -> any AccountService {
+        standard.backedService(with: self)
+    }
+
+    func backedBy(standard: any AccountNotifyStandard) -> any AccountService {
+        standard.backedService(with: self)
+    }
+}
+
+
+extension AccountStorageStandard {
+    fileprivate nonisolated func backedService<Service: AccountService>(with service: Service) -> any AccountService {
+        StorageStandardBackedAccountService(service: service, standard: self)
+    }
+}
+
+
+extension AccountNotifyStandard {
+    fileprivate nonisolated func backedService<Service: AccountService>(with service: Service) -> any AccountService {
+        NotifyStandardBackedAccountService(service: service, standard: self)
+    }
+}

--- a/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
@@ -121,3 +121,5 @@ actor StorageStandardBackedAccountService<Service: AccountService, Standard: Acc
 extension StorageStandardBackedAccountService: EmbeddableAccountService where Service: EmbeddableAccountService {}
 
 extension StorageStandardBackedAccountService: UserIdPasswordAccountService where Service: UserIdPasswordAccountService {}
+
+extension StorageStandardBackedAccountService: IdentityProvider where Service: IdentityProvider {}

--- a/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
@@ -120,14 +120,4 @@ actor StorageStandardBackedAccountService<Service: AccountService, Standard: Acc
 
 extension StorageStandardBackedAccountService: EmbeddableAccountService where Service: EmbeddableAccountService {}
 
-
-extension StorageStandardBackedAccountService: UserIdPasswordAccountService where Service: UserIdPasswordAccountService {
-    func login(userId: String, password: String) async throws {
-        // the standard is queried once the account service calls `supplyAccountDetails`
-        try await accountService.login(userId: userId, password: password)
-    }
-
-    func resetPassword(userId: String) async throws {
-        try await accountService.resetPassword(userId: userId)
-    }
-}
+extension StorageStandardBackedAccountService: UserIdPasswordAccountService where Service: UserIdPasswordAccountService {}

--- a/Sources/SpeziAccount/SpeziAccount.docc/Setup Guides/Initial Setup.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Setup Guides/Initial Setup.md
@@ -122,3 +122,7 @@ struct MyView: View {
 
 - ``AccountSetup``
 - ``AccountOverview``
+
+### Reacting to Events
+
+- ``AccountNotifyStandard``

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -104,7 +104,6 @@ struct AccountOverviewSections: View {
             .alert(Text("CONFIRMATION_REMOVAL", bundle: .module), isPresented: $model.presentingRemovalAlert) {
                 // see the discussion of the AsyncButton in the above alert closure
                 AsyncButton(role: .destructive, state: $destructiveViewState, action: {
-                    print("Deleting at \(service)")
                     try await service.delete()
                     dismiss()
                 }) {

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -104,6 +104,7 @@ struct AccountOverviewSections: View {
             .alert(Text("CONFIRMATION_REMOVAL", bundle: .module), isPresented: $model.presentingRemovalAlert) {
                 // see the discussion of the AsyncButton in the above alert closure
                 AsyncButton(role: .destructive, state: $destructiveViewState, action: {
+                    print("Deleting at \(service)")
                     try await service.delete()
                     dismiss()
                 }) {

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -16,6 +16,7 @@ struct AccountTestsView: View {
     @Environment(\.features) var features
 
     @EnvironmentObject var account: Account
+    @EnvironmentObject var standard: TestStandard
 
     @State var showSetup = false
     @State var showOverview = false
@@ -23,14 +24,9 @@ struct AccountTestsView: View {
 
     
     var body: some View {
-        // of by two
-        NavigationStack { // swiftlint:disable:this closure_body_length
+        NavigationStack {
             List {
-                if let details = account.details {
-                    Section("Account Details") {
-                        Text(details.userId)
-                    }
-                }
+                header
                 Button("Account Setup") {
                     showSetup = true
                 }
@@ -62,6 +58,19 @@ struct AccountTestsView: View {
                         showSetup = false
                     }
                 }
+        }
+    }
+
+    @ViewBuilder var header: some View {
+        if let details = account.details {
+            Section("Account Details") {
+                Text(details.userId)
+            }
+        }
+        if standard.deleteNotified {
+            Section {
+                Text("Got notified about deletion!")
+            }
         }
     }
 

--- a/Tests/UITests/TestApp/AccountTests/TestStandard.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestStandard.swift
@@ -8,10 +8,13 @@
 
 import Spezi
 import SpeziAccount
+import SwiftUI
 
 
 // mock implementation of the AccountStorageStandard
-actor TestStandard: AccountStorageStandard {
+actor TestStandard: AccountStorageStandard, AccountNotifyStandard, ObservableObject, ObservableObjectProvider {
+    @MainActor @Published var deleteNotified = false
+
     var records: [AdditionalRecordId: PartialAccountDetails.Builder] = [:]
 
     func create(_ identifier: AdditionalRecordId, _ details: SignupDetails) async throws {
@@ -39,5 +42,11 @@ actor TestStandard: AccountStorageStandard {
 
     func delete(_ identifier: AdditionalRecordId) async throws {
         records[identifier] = nil
+    }
+
+    @MainActor
+    func deletedAccount() async {
+        print("GOT NOTIFIED ABOUT DELETE!")
+        deleteNotified = true
     }
 }

--- a/Tests/UITests/TestApp/AccountTests/TestStandard.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestStandard.swift
@@ -46,7 +46,6 @@ actor TestStandard: AccountStorageStandard, AccountNotifyStandard, ObservableObj
 
     @MainActor
     func deletedAccount() async {
-        print("GOT NOTIFIED ABOUT DELETE!")
         deleteNotified = true
     }
 }

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -87,7 +87,9 @@ final class AccountOverviewTests: XCTestCase {
 
         sleep(2)
         app.verify()
+
         XCTAssertFalse(app.staticTexts["lelandstanford@stanford.edu"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.staticTexts["Got notified about deletion!"].waitForExistence(timeout: 2.0))
     }
 
     func testEditDiscard() {

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -62,6 +62,10 @@
             argument = "mail"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--default-credentials"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Introduce the AccountNotifyStandard

## :recycle: Current situation & Problem
Currently, there is no way for an App to distinguish between Account logout and removal. This is especially important if the App associates other data (questionnaires, additional user information) with the user account that must be deleted as well.

This PR adds the `AccountNotifyStandard` constraint that allows to get notified about an account removal.

## :gear: Release Notes 
* Add `AccountNotifyStandard`


## :books: Documentation
Documentation was added and updated.


## :white_check_mark: Testing
Tests were added to verify functionality.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
