### PR TITLE
Add Customizable Area to AccountOverview

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,12 +23,6 @@ jobs:
       artifactname: SpeziAccount.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: SpeziAccount
-  build:
-    name: Build Swift Package on Xcode 14
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macos-13"]'
-      scheme: SpeziAccount
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,3 +13,4 @@ Spezi Account Contributors
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Andreas Bauer](https://github.com/Supereg)
+* [Nikolai Madlener](https://github.com/NikolaiMadlener)

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -37,7 +37,7 @@ public struct AccountHeader: View {
     public enum Defaults {
         /// Default caption.
         @_documentation(visibility: internal)
-        public static let caption = LocalizedStringResource("ACCOUNT_HEADER_CAPTION", bundle: .atURL(from: .module))
+        public static let caption = LocalizedStringResource("ACCOUNT_HEADER_CAPTION", bundle: .atURL(from: .module)) // swiftlint:disable:this attributes
     }
     
     @EnvironmentObject private var account: Account

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -32,6 +32,14 @@ import SwiftUI
 /// }
 /// ```
 public struct AccountHeader: View {
+    /// Default values for the ``AccountHeader`` view.
+    @_documentation(visibility: internal)
+    public enum Defaults {
+        /// Default caption.
+        @_documentation(visibility: internal)
+        public static let caption = LocalizedStringResource("ACCOUNT_HEADER_CAPTION", bundle: .atURL(from: .module))
+    }
+    
     @EnvironmentObject private var account: Account
     private var caption: LocalizedStringResource
     
@@ -56,8 +64,8 @@ public struct AccountHeader: View {
     
     /// Display a new Account Header.
     /// - Parameter caption: A descriptive text displayed under the account name giving the user a brief explanation of what to expect when they interact with the header.
-    public init(caption: LocalizedStringResource? = nil) {
-        self.caption = caption ?? LocalizedStringResource("ACCOUNT_HEADER_CAPTION", bundle: .atURL(from: .module))
+    public init(caption: LocalizedStringResource = Defaults.caption) {
+        self.caption = caption
     }
 }
 

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -9,6 +9,28 @@
 import SpeziViews
 import SwiftUI
 
+/// A summary view for ``SpeziAccountOverview`` that can be used as a Button to link to ``SpeziAccountOverview``.
+///
+/// Below is a short code example on how to use the `AccountHeader` view.
+///
+/// ```swift
+/// struct MyView: View {
+///     var body: some View {
+///         NavigationStack {
+///             Form {
+///                 Section {
+///                     NavigationLink {
+///                         AccountOverview()
+///                     } label: {
+///                         AccountHeader(details: details)
+///                     }
+///                 }
+///             }
+///         }
+///     }
+/// }
+/// ```
+
 
 public struct AccountHeader: View {
     private let model: AccountDisplayModel

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -1,0 +1,76 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import SpeziViews
+
+
+public struct AccountHeader: View {
+    private let model: AccountDisplayModel
+    
+    public var body: some View {
+        HStack {
+            Group {
+                if let profileViewName = model.profileViewName {
+                    UserProfileView(name: profileViewName)
+                        .frame(height: 60)
+                } else {
+                    Image(systemName: "person.circle.fill")
+                        .resizable()
+                        .frame(width: 60, height: 60)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundColor(Color(.systemGray))
+                        .accessibilityHidden(true)
+                }
+            }
+            .accessibilityHidden(true)
+            VStack(alignment: .leading) {
+                Text(model.accountHeadline)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                
+                Text("Email, Password, Preferences").font(.caption)
+            }
+        }
+    }
+    
+    public init(details: AccountDetails) {
+        self.model = AccountDisplayModel(details: details)
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    let details = AccountDetails.Builder()
+        .set(\.userId, value: "andi.bauer@tum.de")
+        .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
+        .build(owner: MockUserIdPasswordAccountService())
+    
+    return AccountHeader(details: details)
+}
+
+#Preview {
+    let details = AccountDetails.Builder()
+        .set(\.userId, value: "andi.bauer@tum.de")
+        .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
+        .build(owner: MockUserIdPasswordAccountService())
+    
+    return NavigationStack {
+        Form {
+            Section {
+                NavigationLink {
+                    AccountOverview()
+                } label: {
+                    AccountHeader(details: details)
+                }
+            }
+        }
+    }.environmentObject(Account(MockUserIdPasswordAccountService()))
+}
+#endif

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
 import SpeziViews
+import SwiftUI
 
 
 public struct AccountHeader: View {

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -33,11 +33,30 @@ import SwiftUI
 ///         AccountOverview()
 ///     }
 /// }
+/// ```
+///
+/// Optionally, additional views can be passed to AccountOverview within the trailing closure, providing the opportunity for customization and extension of the view."
+/// Below is a short code example.
+///
+/// ```swift
+/// struct MyView: View {
+///     var body: some View {
+///         AccountOverview {
+///             NavigationLink {
+///                 // ... next view
+///             } label: {
+///                 Text("General Settings")
+///             }
+///         }
+///     }
+/// }
+/// ```
 ///
 /// - Note: The ``init(isEditing:)`` initializer allows to pass an optional `Bool` Binding to retrieve the
 ///     current edit mode of the view. This can be helpful to, e.g., render a custom `Close` Button if the
 ///     view is not editing when presenting the AccountOverview in a sheet.
-/// ```
+
+
 public struct AccountOverview<Content: View>: View {
     @EnvironmentObject private var account: Account
     

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -102,16 +102,14 @@ struct AccountOverView_Previews: PreviewProvider {
         NavigationStack {
             AccountOverview() {
                 NavigationLink {
-                    VStack {}
+                    Text("")
                         .navigationTitle(Text("Settings"))
-                        .navigationBarTitleDisplayMode(.inline)
                 } label: {
                     Text("General Settings")
                 }
                 NavigationLink {
-                    VStack {}
+                    Text("")
                         .navigationTitle(Text("Package Dependencies"))
-                        .navigationBarTitleDisplayMode(.inline)
                 } label: {
                     Text("License Information")
                 }

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -100,7 +100,7 @@ struct AccountOverView_Previews: PreviewProvider {
     
     static var previews: some View {
         NavigationStack {
-            AccountOverview() {
+            AccountOverview {
                 NavigationLink {
                     Text("")
                         .navigationTitle(Text("Settings"))

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -101,10 +101,18 @@ struct AccountOverView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             AccountOverview() {
-                NavigationLink {} label: {
+                NavigationLink {
+                    VStack {}
+                        .navigationTitle(Text("Settings"))
+                        .navigationBarTitleDisplayMode(.inline)
+                } label: {
                     Text("General Settings")
                 }
-                NavigationLink {} label: {
+                NavigationLink {
+                    VStack {}
+                        .navigationTitle(Text("Package Dependencies"))
+                        .navigationBarTitleDisplayMode(.inline)
+                } label: {
                     Text("License Information")
                 }
             }

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -35,7 +35,7 @@ import SwiftUI
 /// }
 /// ```
 ///
-/// Optionally, additional views can be passed to AccountOverview within the trailing closure, providing the opportunity for customization and extension of the view."
+/// Optionally, additional sections can be passed to AccountOverview within the trailing closure, providing the opportunity for customization and extension of the view."
 /// Below is a short code example.
 ///
 /// ```swift
@@ -55,14 +55,12 @@ import SwiftUI
 /// - Note: The ``init(isEditing:)`` initializer allows to pass an optional `Bool` Binding to retrieve the
 ///     current edit mode of the view. This can be helpful to, e.g., render a custom `Close` Button if the
 ///     view is not editing when presenting the AccountOverview in a sheet.
-
-
-public struct AccountOverview<Content: View>: View {
+public struct AccountOverview<AdditionalSections: View>: View {
     @EnvironmentObject private var account: Account
     
     @Binding private var isEditing: Bool
     
-    let additionalContent: Content
+    let additionalSections: AdditionalSections
     
     public var body: some View {
         VStack {
@@ -75,10 +73,10 @@ public struct AccountOverview<Content: View>: View {
                         details: details,
                         isEditing: $isEditing
                     ) {
-                        additionalContent
+                        additionalSections
                     }
                 }
-                .padding(.top, -20)
+                    .padding(.top, -20)
             } else {
                 Spacer()
                 MissingAccountDetailsWarning()
@@ -88,24 +86,18 @@ public struct AccountOverview<Content: View>: View {
                 Spacer()
             }
         }
-        .navigationTitle(Text("ACCOUNT_OVERVIEW", bundle: .module))
-        .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(Text("ACCOUNT_OVERVIEW", bundle: .module))
+            .navigationBarTitleDisplayMode(.inline)
     }
     
     
     /// Display a new Account Overview.
-    /// - Parameter isEditing: A Binding that allows you to read the current editing state of the Account Overview view.
-    public init(isEditing: Binding<Bool> = .constant(false), @ViewBuilder additionalContent: () -> Content) {
+    /// - Parameters:
+    ///   - isEditing: A Binding that allows you to read the current editing state of the Account Overview view.
+    ///   - additionalSections: Optional additional sections displayed between the other AccountOverview information and the log out button.
+    public init(isEditing: Binding<Bool> = .constant(false), @ViewBuilder additionalSections: () -> AdditionalSections = { EmptyView() }) {
         self._isEditing = isEditing
-        self.additionalContent = additionalContent()
-    }
-}
-
-/// Makes passing additionalContent optional
-extension AccountOverview where Content == EmptyView {
-    init(isEditing: Binding<Bool> = .constant(false)) {
-        self._isEditing = isEditing
-        self.additionalContent = EmptyView()
+        self.additionalSections = additionalSections()
     }
 }
 
@@ -134,12 +126,12 @@ struct AccountOverView_Previews: PreviewProvider {
                 }
             }
         }
-        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
         
         NavigationStack {
             AccountOverview()
         }
-        .environmentObject(Account())
+            .environmentObject(Account())
     }
 }
 #endif

--- a/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/de.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 "VALUE_ADD %@" = "%@ Hinzufügen";
 "CHANGE_PASSWORD" = "Passwort Ändern";
 
+// MARK - Account Header
+"ACCOUNT_HEADER_CAPTION" = "Kontoinformationen & Details";
+
 // MARK - Confirmation Dialogs
 "CONFIRMATION_DISCARD_CHANGES_TITLE" = "Willst du alle Änderungen verwerfen?";
 "CONFIRMATION_DISCARD_INPUT_TITLE" = "Willst du deine Eingaben verwerfen?";

--- a/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
+++ b/Sources/SpeziAccount/Resources/en.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 "VALUE_ADD %@" = "Add %@";
 "CHANGE_PASSWORD" = "Change Password";
 
+// MARK - Account Header
+"ACCOUNT_HEADER_CAPTION" = "Account Information & Details";
+
 // MARK - Confirmation Dialogs
 "CONFIRMATION_DISCARD_CHANGES_TITLE" = "Are you sure you want to discard your changes?";
 "CONFIRMATION_DISCARD_INPUT_TITLE" = "Are you sure you want to discard your input?";

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -250,7 +250,7 @@ struct AccountOverviewSections_Previews: PreviewProvider {
 
     static var previews: some View {
         NavigationStack {
-            AccountOverview() {
+            AccountOverview {
                 NavigationLink {
                     Text("")
                 } label: {

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -15,35 +15,35 @@ import SwiftUI
 struct AccountOverviewSections<Content: View>: View {
     let additionalContent: Content
     private let accountDetails: AccountDetails
-
+    
     private var service: any AccountService {
         accountDetails.accountService
     }
-
+    
     @EnvironmentObject private var account: Account
-
+    
     @Environment(\.logger) private var logger
     @Environment(\.editMode) private var editMode
     @Environment(\.dismiss) private var dismiss
-
+    
     @StateObject private var model: AccountOverviewFormViewModel
     @Binding private var isEditing: Bool
-
+    
     @State private var viewState: ViewState = .idle
     // separate view state for any destructive actions like logout or account removal
     @State private var destructiveViewState: ViewState = .idle
     @FocusState private var focusedDataEntry: String? // see `AccountKey.Type/focusState`
-
-
+    
+    
     var isProcessing: Bool {
         viewState == .processing || destructiveViewState == .processing
     }
-
-
+    
+    
     var body: some View {
         AccountOverviewHeader(details: accountDetails)
-            // Every `Section` is basically a `Group` view. So we have to be careful where to place modifiers
-            // as they might otherwise be rendered for every element in the Section/Group, e.g., placing multiple buttons.
+        // Every `Section` is basically a `Group` view. So we have to be careful where to place modifiers
+        // as they might otherwise be rendered for every element in the Section/Group, e.g., placing multiple buttons.
             .interactiveDismissDisabled(model.hasUnsavedChanges || isProcessing)
             .navigationBarBackButtonHidden(editMode?.wrappedValue.isEditing ?? false || isProcessing)
             .viewStateAlert(state: $viewState)
@@ -67,8 +67,8 @@ struct AccountOverviewSections<Content: View>: View {
                                 Text("EDIT", bundle: .module)
                             }
                         }
-                            .disabled(editMode?.wrappedValue.isEditing == true && model.validationEngines.isDisplayingValidationErrors)
-                            .environment(\.defaultErrorDescription, model.defaultErrorDescription)
+                        .disabled(editMode?.wrappedValue.isEditing == true && model.validationEngines.isDisplayingValidationErrors)
+                        .environment(\.defaultErrorDescription, model.defaultErrorDescription)
                     }
                 }
             }
@@ -96,8 +96,8 @@ struct AccountOverviewSections<Content: View>: View {
                 }) {
                     Text("UP_LOGOUT", bundle: .module)
                 }
-                    .environment(\.defaultErrorDescription, .init("UP_LOGOUT_FAILED_DEFAULT_ERROR", bundle: .atURL(from: .module)))
-
+                .environment(\.defaultErrorDescription, .init("UP_LOGOUT_FAILED_DEFAULT_ERROR", bundle: .atURL(from: .module)))
+                
                 Button(role: .cancel, action: {}) {
                     Text("CANCEL", bundle: .module)
                 }
@@ -110,8 +110,8 @@ struct AccountOverviewSections<Content: View>: View {
                 }) {
                     Text("DELETE", bundle: .module)
                 }
-                    .environment(\.defaultErrorDescription, .init("REMOVE_DEFAULT_ERROR", bundle: .atURL(from: .module)))
-
+                .environment(\.defaultErrorDescription, .init("REMOVE_DEFAULT_ERROR", bundle: .atURL(from: .module)))
+                
                 Button(role: .cancel, action: {}) {
                     Text("CANCEL", bundle: .module)
                 }
@@ -122,7 +122,7 @@ struct AccountOverviewSections<Content: View>: View {
                 // sync the edit mode with the outer view
                 isEditing = newValue
             }
-
+        
         Section {
             NavigationLink {
                 NameOverview(model: model, details: accountDetails)
@@ -135,35 +135,35 @@ struct AccountOverviewSections<Content: View>: View {
                 model.accountSecurityLabel(account.configuration)
             }
         }
-
+        
         sectionsView
             .injectEnvironmentObjects(service: service, model: model, focusState: $focusedDataEntry)
             .animation(nil, value: editMode?.wrappedValue)
         
-        Section {
-            additionalContent
-        }
+        additionalContent
         
-        HStack {
-            if editMode?.wrappedValue.isEditing == true {
-                AsyncButton(role: .destructive, state: $destructiveViewState, action: {
-                    // While the action closure itself is not async, we rely on ability to render loading indicator
-                    // of the AsyncButton which based on the externally supplied viewState.
-                    model.presentingRemovalAlert = true
-                }) {
-                    Text("DELETE_ACCOUNT", bundle: .module)
-                }
-            } else {
-                AsyncButton(role: .destructive, state: $destructiveViewState, action: {
-                    model.presentingLogoutAlert = true
-                }) {
-                    Text("UP_LOGOUT", bundle: .module)
+        Section {
+            HStack {
+                if editMode?.wrappedValue.isEditing == true {
+                    AsyncButton(role: .destructive, state: $destructiveViewState, action: {
+                        // While the action closure itself is not async, we rely on ability to render loading indicator
+                        // of the AsyncButton which based on the externally supplied viewState.
+                        model.presentingRemovalAlert = true
+                    }) {
+                        Text("DELETE_ACCOUNT", bundle: .module)
+                    }
+                } else {
+                    AsyncButton(role: .destructive, state: $destructiveViewState, action: {
+                        model.presentingLogoutAlert = true
+                    }) {
+                        Text("UP_LOGOUT", bundle: .module)
+                    }
                 }
             }
-        }
             .frame(maxWidth: .infinity, alignment: .center)
+        }
     }
-
+    
     @ViewBuilder private var sectionsView: some View {
         ForEach(model.editableAccountKeys(details: accountDetails).elements, id: \.key) { category, accountKeys in
             if !sectionIsEmpty(accountKeys) {
@@ -172,13 +172,13 @@ struct AccountOverviewSections<Content: View>: View {
                     let forEachWrappers = accountKeys.map { key in
                         ForEachAccountKeyWrapper(key)
                     }
-
+                    
                     ForEach(forEachWrappers, id: \.id) { wrapper in
                         AccountKeyEditRow(details: accountDetails, for: wrapper.accountKey, model: model)
                     }
-                        .onDelete { indexSet in
-                            model.deleteAccountKeys(at: indexSet, in: accountKeys)
-                        }
+                    .onDelete { indexSet in
+                        model.deleteAccountKeys(at: indexSet, in: accountKeys)
+                    }
                 } header: {
                     if let title = category.categoryTitle {
                         Text(title)
@@ -187,7 +187,7 @@ struct AccountOverviewSections<Content: View>: View {
             }
         }
     }
-
+    
     init(
         account: Account,
         details accountDetails: AccountDetails,
@@ -206,25 +206,25 @@ struct AccountOverviewSections<Content: View>: View {
             editMode?.wrappedValue = .active
             return
         }
-
+        
         guard !model.modifiedDetailsBuilder.isEmpty else {
             logger.debug("Not saving anything, as there were no changes!")
             model.discardChangesAction(editMode: editMode)
             return
         }
-
+        
         guard model.validationEngines.validateSubviews(focusState: $focusedDataEntry) else {
             logger.debug("Some input validation failed. Staying in edit mode!")
             return
         }
-
+        
         focusedDataEntry = nil
-
+        
         logger.debug("Exiting edit mode and saving \(model.modifiedDetailsBuilder.count) changes to AccountService!")
-
+        
         try await model.updateAccountDetails(details: accountDetails, editMode: editMode)
     }
-
+    
     /// Computes if a given `Section` is empty. This is the case if we are **not** currently editing
     /// and the accountDetails don't have values stored for any of the provided ``AccountKey``.
     private func sectionIsEmpty(_ accountKeys: [any AccountKey.Type]) -> Bool {
@@ -232,7 +232,7 @@ struct AccountOverviewSections<Content: View>: View {
             // there is always UI presented in EDIT mode
             return false
         }
-
+        
         // we don't have to check for `addedAccountKeys` as these are only relevant in edit mode
         return accountKeys.allSatisfy { element in
             !accountDetails.contains(element)
@@ -247,23 +247,25 @@ struct AccountOverviewSections_Previews: PreviewProvider {
         .set(\.userId, value: "andi.bauer@tum.de")
         .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
         .set(\.genderIdentity, value: .male)
-
+    
     static var previews: some View {
         NavigationStack {
             AccountOverview {
-                NavigationLink {
-                    Text("")
-                } label: {
-                    Text("General Settings")
-                }
-                NavigationLink {
-                    Text("")
-                } label: {
-                    Text("License Information")
+                Section(header: Text("App")) {
+                    NavigationLink {
+                        Text("")
+                    } label: {
+                        Text("General Settings")
+                    }
+                    NavigationLink {
+                        Text("")
+                    } label: {
+                        Text("License Information")
+                    }
                 }
             }
         }
-            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -12,7 +12,8 @@ import SwiftUI
 
 
 /// A internal subview of ``AccountOverview`` that expects to be embedded into a `Form`.
-struct AccountOverviewSections: View {
+struct AccountOverviewSections<Content: View>: View {
+    let additionalContent: Content
     private let accountDetails: AccountDetails
 
     private var service: any AccountService {
@@ -138,7 +139,11 @@ struct AccountOverviewSections: View {
         sectionsView
             .injectEnvironmentObjects(service: service, model: model, focusState: $focusedDataEntry)
             .animation(nil, value: editMode?.wrappedValue)
-
+        
+        Section {
+            additionalContent
+        }
+        
         HStack {
             if editMode?.wrappedValue.isEditing == true {
                 AsyncButton(role: .destructive, state: $destructiveViewState, action: {
@@ -183,18 +188,19 @@ struct AccountOverviewSections: View {
         }
     }
 
-
     init(
         account: Account,
         details accountDetails: AccountDetails,
-        isEditing: Binding<Bool>
+        isEditing: Binding<Bool>,
+        @ViewBuilder additionalContent: () -> Content
     ) {
         self.accountDetails = accountDetails
         self._model = StateObject(wrappedValue: AccountOverviewFormViewModel(account: account))
         self._isEditing = isEditing
+        self.additionalContent = additionalContent()
     }
-
-
+    
+    
     private func editButtonAction() async throws {
         if editMode?.wrappedValue.isEditing == false {
             editMode?.wrappedValue = .active
@@ -244,7 +250,14 @@ struct AccountOverviewSections_Previews: PreviewProvider {
 
     static var previews: some View {
         NavigationStack {
-            AccountOverview()
+            AccountOverview() {
+                NavigationLink {} label: {
+                    Text("General Settings")
+                }
+                NavigationLink {} label: {
+                    Text("License Information")
+                }
+            }
         }
             .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
     }

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -12,8 +12,8 @@ import SwiftUI
 
 
 /// A internal subview of ``AccountOverview`` that expects to be embedded into a `Form`.
-struct AccountOverviewSections<Content: View>: View {
-    let additionalContent: Content
+struct AccountOverviewSections<AdditionalSections: View>: View {
+    let additionalSections: AdditionalSections
     private let accountDetails: AccountDetails
     
     private var service: any AccountService {
@@ -42,8 +42,8 @@ struct AccountOverviewSections<Content: View>: View {
     
     var body: some View {
         AccountOverviewHeader(details: accountDetails)
-        // Every `Section` is basically a `Group` view. So we have to be careful where to place modifiers
-        // as they might otherwise be rendered for every element in the Section/Group, e.g., placing multiple buttons.
+            // Every `Section` is basically a `Group` view. So we have to be careful where to place modifiers
+            // as they might otherwise be rendered for every element in the Section/Group, e.g., placing multiple buttons.
             .interactiveDismissDisabled(model.hasUnsavedChanges || isProcessing)
             .navigationBarBackButtonHidden(editMode?.wrappedValue.isEditing ?? false || isProcessing)
             .viewStateAlert(state: $viewState)
@@ -67,8 +67,8 @@ struct AccountOverviewSections<Content: View>: View {
                                 Text("EDIT", bundle: .module)
                             }
                         }
-                        .disabled(editMode?.wrappedValue.isEditing == true && model.validationEngines.isDisplayingValidationErrors)
-                        .environment(\.defaultErrorDescription, model.defaultErrorDescription)
+                            .disabled(editMode?.wrappedValue.isEditing == true && model.validationEngines.isDisplayingValidationErrors)
+                            .environment(\.defaultErrorDescription, model.defaultErrorDescription)
                     }
                 }
             }
@@ -110,7 +110,7 @@ struct AccountOverviewSections<Content: View>: View {
                 }) {
                     Text("DELETE", bundle: .module)
                 }
-                .environment(\.defaultErrorDescription, .init("REMOVE_DEFAULT_ERROR", bundle: .atURL(from: .module)))
+                    .environment(\.defaultErrorDescription, .init("REMOVE_DEFAULT_ERROR", bundle: .atURL(from: .module)))
                 
                 Button(role: .cancel, action: {}) {
                     Text("CANCEL", bundle: .module)
@@ -140,7 +140,7 @@ struct AccountOverviewSections<Content: View>: View {
             .injectEnvironmentObjects(service: service, model: model, focusState: $focusedDataEntry)
             .animation(nil, value: editMode?.wrappedValue)
         
-        additionalContent
+        additionalSections
         
         Section {
             HStack {
@@ -160,7 +160,7 @@ struct AccountOverviewSections<Content: View>: View {
                     }
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .center)
+                .frame(maxWidth: .infinity, alignment: .center)
         }
     }
     
@@ -176,9 +176,9 @@ struct AccountOverviewSections<Content: View>: View {
                     ForEach(forEachWrappers, id: \.id) { wrapper in
                         AccountKeyEditRow(details: accountDetails, for: wrapper.accountKey, model: model)
                     }
-                    .onDelete { indexSet in
-                        model.deleteAccountKeys(at: indexSet, in: accountKeys)
-                    }
+                        .onDelete { indexSet in
+                            model.deleteAccountKeys(at: indexSet, in: accountKeys)
+                        }
                 } header: {
                     if let title = category.categoryTitle {
                         Text(title)
@@ -192,12 +192,12 @@ struct AccountOverviewSections<Content: View>: View {
         account: Account,
         details accountDetails: AccountDetails,
         isEditing: Binding<Bool>,
-        @ViewBuilder additionalContent: () -> Content
+        @ViewBuilder additionalSections: (() -> AdditionalSections) = { EmptyView() }
     ) {
         self.accountDetails = accountDetails
         self._model = StateObject(wrappedValue: AccountOverviewFormViewModel(account: account))
         self._isEditing = isEditing
-        self.additionalContent = additionalContent()
+        self.additionalSections = additionalSections()
     }
     
     
@@ -265,7 +265,7 @@ struct AccountOverviewSections_Previews: PreviewProvider {
                 }
             }
         }
-        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -251,10 +251,14 @@ struct AccountOverviewSections_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             AccountOverview() {
-                NavigationLink {} label: {
+                NavigationLink {
+                    Text("")
+                } label: {
                     Text("General Settings")
                 }
-                NavigationLink {} label: {
+                NavigationLink {
+                    Text("")
+                } label: {
                     Text("License Information")
                 }
             }

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -84,7 +84,6 @@ struct PasswordChangeSheet: View {
                 Divider()
                     .gridCellUnsizedAxes(.horizontal)
 
-
                 PasswordKey.DataEntry($repeatPassword)
                     .environment(\.passwordFieldType, .repeat)
                     .focused($focusedDataEntry, equals: "$-newPassword")

--- a/Sources/SpeziAccount/Views/AccountSummaryBox.swift
+++ b/Sources/SpeziAccount/Views/AccountSummaryBox.swift
@@ -58,6 +58,7 @@ public struct AccountSummaryBox: View {
     }
 }
 
+
 #if DEBUG
 struct AccountSummary_Previews: PreviewProvider {
     static let emailDetails = AccountDetails.Builder()

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -49,9 +49,8 @@ struct AccountTestsView: View {
                 NavigationStack {
                     AccountOverview(isEditing: $isEditing) {
                         NavigationLink {
-                            VStack {}
+                            Text("")
                                 .navigationTitle(Text("Package Dependencies"))
-                                .navigationBarTitleDisplayMode(.inline)
                         } label: {
                             Text("License Information")
                         }

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -68,43 +68,42 @@ struct AccountTestsView: View {
             }
         }
     }
-}
-
-@ViewBuilder var header: some View {
-    if let details = account.details {
-        Section("Account Details") {
-            Text(details.userId)
+    
+    @ViewBuilder var header: some View {
+        if let details = account.details {
+            Section("Account Details") {
+                Text(details.userId)
+            }
         }
-    }
-    if standard.deleteNotified {
-        Section {
-            Text("Got notified about deletion!")
-        }
-    }
-}
-
-
-@ViewBuilder var finishButton: some View {
-    Button(action: {
-        showSetup = false
-    }, label: {
-        Text("Finish")
-            .frame(maxWidth: .infinity, minHeight: 38)
-    })
-    .buttonStyle(.borderedProminent)
-}
-
-
-@ToolbarContentBuilder
-func toolbar(closing flag: Binding<Bool>) -> some ToolbarContent {
-    if !isEditing {
-        ToolbarItem(placement: .cancellationAction) {
-            Button("Close") {
-                flag.wrappedValue = false
+        if standard.deleteNotified {
+            Section {
+                Text("Got notified about deletion!")
             }
         }
     }
-}
+
+
+    @ViewBuilder var finishButton: some View {
+        Button(action: {
+            showSetup = false
+        }, label: {
+            Text("Finish")
+                .frame(maxWidth: .infinity, minHeight: 38)
+        })
+        .buttonStyle(.borderedProminent)
+    }
+
+
+    @ToolbarContentBuilder
+    func toolbar(closing flag: Binding<Bool>) -> some ToolbarContent {
+        if !isEditing {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Close") {
+                    flag.wrappedValue = false
+                }
+            }
+        }
+    }
 }
 
 

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -14,14 +14,14 @@ import SwiftUI
 
 struct AccountTestsView: View {
     @Environment(\.features) var features
-
+    
     @EnvironmentObject var account: Account
     @EnvironmentObject var standard: TestStandard
-
+    
     @State var showSetup = false
     @State var showOverview = false
     @State var isEditing = false
-
+    
     
     var body: some View {
         NavigationStack {
@@ -34,68 +34,77 @@ struct AccountTestsView: View {
                     showOverview = true
                 }
             }
-                .navigationTitle("Spezi Account")
-                .sheet(isPresented: $showSetup) {
-                    NavigationStack {
-                        AccountSetup {
-                            finishButton
+            .navigationTitle("Spezi Account")
+            .sheet(isPresented: $showSetup) {
+                NavigationStack {
+                    AccountSetup {
+                        finishButton
+                    }
+                    .toolbar {
+                        toolbar(closing: $showSetup)
+                    }
+                }
+            }
+            .sheet(isPresented: $showOverview) {
+                NavigationStack {
+                    AccountOverview(isEditing: $isEditing) {
+                        NavigationLink {
+                            VStack {}
+                                .navigationTitle(Text("Package Dependencies"))
+                                .navigationBarTitleDisplayMode(.inline)
+                        } label: {
+                            Text("License Information")
                         }
-                            .toolbar {
-                                toolbar(closing: $showSetup)
-                            }
                     }
                 }
-                .sheet(isPresented: $showOverview) {
-                    NavigationStack {
-                        AccountOverview(isEditing: $isEditing)
-                            .toolbar {
-                                toolbar(closing: $showOverview)
-                            }
-                    }
-                }
-                .onChange(of: account.signedIn) { newValue in
-                    if newValue {
-                        showSetup = false
-                    }
-                }
-        }
-    }
-
-    @ViewBuilder var header: some View {
-        if let details = account.details {
-            Section("Account Details") {
-                Text(details.userId)
-            }
-        }
-        if standard.deleteNotified {
-            Section {
-                Text("Got notified about deletion!")
-            }
-        }
-    }
-
-
-    @ViewBuilder var finishButton: some View {
-        Button(action: {
-            showSetup = false
-        }, label: {
-            Text("Finish")
-                .frame(maxWidth: .infinity, minHeight: 38)
-        })
-            .buttonStyle(.borderedProminent)
-    }
-
-
-    @ToolbarContentBuilder
-    func toolbar(closing flag: Binding<Bool>) -> some ToolbarContent {
-        if !isEditing {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("Close") {
-                    flag.wrappedValue = false
+                .toolbar {
+                    toolbar(closing: $showOverview)
                 }
             }
         }
+        .onChange(of: account.signedIn) { newValue in
+            if newValue {
+                showSetup = false
+            }
+        }
     }
+}
+
+@ViewBuilder var header: some View {
+    if let details = account.details {
+        Section("Account Details") {
+            Text(details.userId)
+        }
+    }
+    if standard.deleteNotified {
+        Section {
+            Text("Got notified about deletion!")
+        }
+    }
+}
+
+
+@ViewBuilder var finishButton: some View {
+    Button(action: {
+        showSetup = false
+    }, label: {
+        Text("Finish")
+            .frame(maxWidth: .infinity, minHeight: 38)
+    })
+    .buttonStyle(.borderedProminent)
+}
+
+
+@ToolbarContentBuilder
+func toolbar(closing flag: Binding<Bool>) -> some ToolbarContent {
+    if !isEditing {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("Close") {
+                flag.wrappedValue = false
+            }
+        }
+    }
+}
 }
 
 
@@ -105,14 +114,14 @@ struct AccountTestsView_Previews: PreviewProvider {
         .set(\.userId, value: "andi.bauer@tum.de")
         .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
         .set(\.genderIdentity, value: .male)
-
+    
     static var previews: some View {
         AccountTestsView()
             .environmentObject(Account(TestAccountService(.emailAddress)))
-
+        
         AccountTestsView()
             .environmentObject(Account(building: details, active: TestAccountService(.emailAddress)))
-
+        
         AccountTestsView()
             .environmentObject(Account())
     }

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -30,6 +30,8 @@ final class AccountOverviewTests: XCTestCase {
         overview.verifyExistence(text: "Gender Identity, Male")
 
         overview.verifyExistence(text: "Date of Birth, Mar 9, 1824")
+        
+        overview.verifyExistence(text: "License Information")
 
         XCTAssertTrue(overview.buttons["Logout"].waitForExistence(timeout: 0.5))
     }
@@ -243,5 +245,14 @@ final class AccountOverviewTests: XCTestCase {
         sleep(2)
 
         XCTAssertFalse(overview.secureTextFields["enter password"].waitForExistence(timeout: 2.0))
+    }
+    
+    func testLicenseOverview() throws {
+        let app = TestApp.launch(defaultCredentials: true)
+        let overview = app.openAccountOverview()
+
+        overview.tap(button: "License Information")
+        sleep(2)
+        XCTAssertTrue(overview.navigationBars.staticTexts["Package Dependencies"].waitForExistence(timeout: 6.0))
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add Customizable Area to AccountOverview

## :recycle: Current situation & Problem
Like described in issue #25, some applications like the Spezi Template application could display some additional information such as licensing information or other settings at the bottom of the Account Overview.
Furthermore, some developers might want to do it the other way around and link to account information within a settings page.

## :bulb: Proposed Solution
Add footer components to AccountOverview, as suggested by @PSchmiedmayer
Implement an additional "AccountHeader" that looks something like the one in the Apple Settings app, as suggested by @Supereg

## :gear: Release Notes 
This PR adds two major things. 

1. A customizable content section ViewBuilder to the `AccountOverview`. Simply pass any view as a trailing closure of AccountOverview and it will be rendered as a Section right between the other AccountOverview information and the log out button. Here is an example:
```
AccountOverview() {
    NavigationLink {
        // ...
    } label: {
        Text("General Settings")
    }
    NavigationLink {
        // ...
    } label: {
        Text("License Information")
    }
}
```
<img width="255" alt="Screenshot 2023-09-27 at 17 30 04" src="https://github.com/StanfordSpezi/SpeziAccount/assets/33159293/6a34258a-0f0d-4c73-85bb-8a6311bc1828">  

2. A `AccountHeader`, similar to the one of the iOS Settings App, that could be used as a button that brings a user to the `AccountOverview`. Here is an example:
```
Section {
    NavigationLink {
        AccountOverview()
    } label: {
        AccountHeader(details: details)
    }
}
```
<img width="251" alt="Screenshot 2023-09-27 at 17 29 33" src="https://github.com/StanfordSpezi/SpeziAccount/assets/33159293/e9d4f3aa-b5f2-4a62-9843-99e88ae77e1d">


## :books: Documentation
*in progress*


## :white_check_mark: Testing
UI tests for the customizable content section have been written.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
