### PR TITLE
Make the StandardBacked protocol visible to the outside

### DIFF
--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -210,7 +210,7 @@ public class Account: ObservableObject, Sendable {
         // Account details will always get built by the respective Account Service. Therefore, we need to patch it
         // if they are wrapped into a StandardBacked one such that the `AccountDetails` carry the correct reference.
         for service in registeredAccountServices {
-            if let standardBacked = service as? any StandardBacked,
+            if let standardBacked = service as? any _StandardBacked,
                standardBacked.isBacking(service: details.accountService) {
                 details.patchAccountService(service)
                 break
@@ -224,7 +224,7 @@ public class Account: ObservableObject, Sendable {
             )
         }
 
-        if let standardBacked = details.accountService as? any StandardBacked,
+        if let standardBacked = details.accountService as? any _StandardBacked,
            let storageStandard = standardBacked.standard as? any AccountStorageStandard {
             let recordId = AdditionalRecordId(serviceId: standardBacked.backedId, accountId: details.accountId)
 
@@ -252,7 +252,7 @@ public class Account: ObservableObject, Sendable {
     /// signed in user and notify others that the user logged out (or the account was removed).
     public func removeUserDetails() async {
         if let details,
-           let standardBacked = details.accountService as? any StandardBacked,
+           let standardBacked = details.accountService as? any _StandardBacked,
            let storageStandard = standardBacked.standard as? any AccountStorageStandard {
             let recordId = AdditionalRecordId(serviceId: standardBacked.backedId, accountId: details.accountId)
 

--- a/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/NotifyStandardBackedAccountService.swift
@@ -9,7 +9,7 @@
 import Spezi
 
 
-actor NotifyStandardBackedAccountService<Service: AccountService, Standard: AccountNotifyStandard>: AccountService, StandardBacked {
+actor NotifyStandardBackedAccountService<Service: AccountService, Standard: AccountNotifyStandard>: AccountService, _StandardBacked {
     @AccountReference private var account
 
     let accountService: Service

--- a/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StorageStandardBackedAccountService.swift
@@ -11,7 +11,7 @@ import Spezi
 
 /// An ``AccountService`` implementation for account services with ``SupportedAccountKeys/exactly(_:)`` configuration
 /// to forward unsupported account values to a ``AccountStorageStandard`` implementation.
-actor StorageStandardBackedAccountService<Service: AccountService, Standard: AccountStorageStandard>: AccountService, StandardBacked {
+actor StorageStandardBackedAccountService<Service: AccountService, Standard: AccountStorageStandard>: AccountService, _StandardBacked {
     @AccountReference private var account
 
     let accountService: Service

--- a/Sources/SpeziAccount/AccountService/Wrapper/_StandardBacked.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/_StandardBacked.swift
@@ -10,43 +10,50 @@ import Spezi
 
 
 /// Internal marker protocol to determine what ``AccountService`` require assistance by a ``AccountStorageStandard``.
-protocol StandardBacked: AccountService {
+public protocol _StandardBacked: AccountService { // swiftlint:disable:this type_name
     associatedtype Service: AccountService
     associatedtype AccountStandard: Standard
 
     var accountService: Service { get }
     var standard: AccountStandard { get }
 
+    /// Retrieves the underlying account service, resolving multiple levels of nesting.
+    var underlyingService: any AccountService { get }
+
     init(service: Service, standard: AccountStandard)
 
+    /// ObjectIdentifier-based check if they underlying account service equals the provided one.
     func isBacking(service accountService: any AccountService) -> Bool
 
     func preUserDetailsSupply(recordId: AdditionalRecordId) async throws
 }
 
 
-extension StandardBacked {
-    var backedId: String {
-        if let nestedBacked = accountService as? any StandardBacked {
-            return nestedBacked.backedId
-        }
-
-        return accountService.id
+extension _StandardBacked {
+    /// The account service id of the underlying account service
+    public var backedId: String {
+        underlyingService.id
     }
 
-
-    func isBacking(service: any AccountService) -> Bool {
-        if let nestedBacked = self.accountService as? any StandardBacked {
-            return nestedBacked.isBacking(service: service)
+    /// Recursively retrieves the innermost account service.
+    public var underlyingService: any AccountService {
+        if let nestedBacked = accountService as? any _StandardBacked {
+            return nestedBacked.underlyingService
         }
-        return self.accountService.objId == service.objId
+        return accountService
     }
 
-    func preUserDetailsSupply(recordId: AdditionalRecordId) async throws {}
+    /// ObjectIdentifier-based check if they underlying account service equals the provided one.
+    public func isBacking(service: any AccountService) -> Bool {
+        underlyingService.objId == service.objId
+    }
+
+    /// Default implementation.
+    public func preUserDetailsSupply(recordId: AdditionalRecordId) async throws {}
 }
 
 
-extension StandardBacked {
+extension _StandardBacked {
     func signUp(signupDetails: SignupDetails) async throws {
         try await accountService.signUp(signupDetails: signupDetails)
     }
@@ -65,7 +72,7 @@ extension StandardBacked {
 }
 
 
-extension StandardBacked where Self: UserIdPasswordAccountService, Service: UserIdPasswordAccountService {
+extension _StandardBacked where Self: UserIdPasswordAccountService, Service: UserIdPasswordAccountService {
     func login(userId: String, password: String) async throws {
         try await accountService.login(userId: userId, password: password)
     }

--- a/Sources/SpeziAccount/AccountService/Wrapper/_StandardBacked.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/_StandardBacked.swift
@@ -43,7 +43,7 @@ extension _StandardBacked {
         return accountService
     }
 
-    /// ObjectIdentifier-based check if they underlying account service equals the provided one.
+    /// An ObjectIdentifier-based check if they underlying account service equals the provided one.
     public func isBacking(service: any AccountService) -> Bool {
         underlyingService.objId == service.objId
     }


### PR DESCRIPTION
# Make the StandardBacked protocol visible to the outside

## :recycle: Current situation & Problem
We currently don't expose the `StandardBacked` protocol to the outside. The protocol can be helpful do more clearly inspect the type of an account service. Therefore, we expose the protocol with an underscore.


## :gear: Release Notes 
* Made `_StandardBacked` public.


## :books: Documentation
* Documentation was added.


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
