### PR TITLE
Upgrade to new Spezi and SpeziFoundation frameworks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "git@github.com:StanfordSpezi/SpeziFoundation.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/simplify-dependencies"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.8.0")),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.6.1")),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.5")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.4"))

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
         .library(name: "SpeziAccount", targets: ["SpeziAccount"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.7.2")),
+        .package(url: "git@github.com:StanfordSpezi/SpeziFoundation.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/simplify-dependencies"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.6.1")),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.5")),
         .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.0.4"))
@@ -30,6 +31,7 @@ let package = Package(
         .target(
             name: "SpeziAccount",
             dependencies: [
+                .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .product(name: "Spezi", package: "Spezi"),
                 .product(name: "SpeziViews", package: "SpeziViews"),
                 .product(name: "SpeziPersonalInfo", package: "SpeziViews"),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "SpeziAccount", targets: ["SpeziAccount"])
     ],
     dependencies: [
-        .package(url: "git@github.com:StanfordSpezi/SpeziFoundation.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", .upToNextMinor(from: "0.1.0")),
         .package(url: "https://github.com/StanfordSpezi/Spezi", .upToNextMinor(from: "0.8.0")),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", .upToNextMinor(from: "0.6.1")),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.5")),

--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -59,8 +59,9 @@ import SwiftUI
 /// - ``init(services:configuration:)``
 /// - ``init(_:configuration:)``
 /// - ``init(building:active:configuration:)``
+@Observable
 @MainActor
-public class Account: ObservableObject, Sendable {
+public final class Account: Sendable {
     private let logger: Logger
 
     /// The `signedIn` property determines if the the current Account context is signed in or not yet signed in.
@@ -71,7 +72,7 @@ public class Account: ObservableObject, Sendable {
     ///     This has the following implications. When `signedIn` is `false`, there might still be a `details` instance present.
     ///     Similarly, when `details` is set to `nil, `signedIn` is guaranteed to be `false`. Otherwise,
     ///     if `details` is set to some value, the `signedIn` property might still be set to `false`.
-    @Published public private(set) var signedIn: Bool
+    public private(set) var signedIn: Bool
 
     /// Provides access to associated data of the currently associated user account.
     ///
@@ -80,7 +81,7 @@ public class Account: ObservableObject, Sendable {
     ///
     /// - Note: The associated ``AccountService`` that is responsible for managing the associated user can be retrieved
     ///     using the ``AccountDetails/accountService`` property.
-    @Published public private(set) var details: AccountDetails?
+    public private(set) var details: AccountDetails?
 
     /// The user-defined configuration of account values that all user accounts need to support.
     public let configuration: AccountValueConfiguration
@@ -103,8 +104,10 @@ public class Account: ObservableObject, Sendable {
     ) {
         self.logger = LoggerKey.defaultValue
 
-        self._signedIn = Published(wrappedValue: details != nil)
-        self._details = Published(wrappedValue: details)
+        // we have to initialize the macro generated properties directly to stay non-isolated.
+        self._signedIn = details != nil
+        self._details = details
+
         self.configuration = supportedConfiguration
         self.registeredAccountServices = services
 

--- a/Sources/SpeziAccount/AccountConfiguration.swift
+++ b/Sources/SpeziAccount/AccountConfiguration.swift
@@ -22,7 +22,7 @@ import XCTRuntimeAssertions
 ///
 /// - Note: For more information on how to provide an ``AccountService`` if you are implementing your own Spezi `Component`
 ///     refer to the <doc:Creating-your-own-Account-Service> article.
-public final class AccountConfiguration: Component, ObservableObjectProvider {
+public final class AccountConfiguration: Module {
     private let logger = LoggerKey.defaultValue
 
     /// The user-defined configuration of account values that all user accounts need to support.
@@ -30,21 +30,12 @@ public final class AccountConfiguration: Component, ObservableObjectProvider {
     /// An array of ``AccountService``s provided directly in the initializer of the configuration object.
     private let providedAccountServices: [any AccountService]
 
-    private var account: Account?
+    @Model private var account = Account() // TODO Model supporting optionals? (+ Modifier?)
 
     @StandardActor private var standard: any Standard
 
     /// The array of ``AccountService``s provided through other Spezi `Components`.
     @Collect private var accountServices: [any AccountService]
-
-
-    public var observableObjects: [any ObservableObject] {
-        guard let account else {
-            preconditionFailure("Tried to access ObservableObjectProvider before \(Self.self).configure() was called")
-        }
-
-        return [account]
-    }
 
 
     /// Initializes a `AccountConfiguration` without directly  providing any ``AccountService`` instances.
@@ -93,7 +84,7 @@ public final class AccountConfiguration: Component, ObservableObjectProvider {
             configuration: configuredAccountKeys
         )
 
-        self.account?.injectWeakAccount(into: standard)
+        self.account.injectWeakAccount(into: standard)
     }
 
     private func verifyConfigurationRequirements(against service: any AccountService) -> any AccountService {

--- a/Sources/SpeziAccount/AccountConfiguration.swift
+++ b/Sources/SpeziAccount/AccountConfiguration.swift
@@ -30,7 +30,7 @@ public final class AccountConfiguration: Module {
     /// An array of ``AccountService``s provided directly in the initializer of the configuration object.
     private let providedAccountServices: [any AccountService]
 
-    @Model private var account = Account() // TODO Model supporting optionals? (+ Modifier?)
+    @Model private var account: Account
 
     @StandardActor private var standard: any Standard
 

--- a/Sources/SpeziAccount/AccountHeader.swift
+++ b/Sources/SpeziAccount/AccountHeader.swift
@@ -41,7 +41,7 @@ public struct AccountHeader: View {
         // swiftlint:disable:previous attributes
     }
     
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     private var caption: LocalizedStringResource
     
     public var body: some View {
@@ -89,12 +89,12 @@ public struct AccountHeader: View {
         .set(\.name, value: PersonNameComponents(givenName: "Andreas", familyName: "Bauer"))
     
     return AccountHeader()
-        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+        .environment(Account(building: details, active: MockUserIdPasswordAccountService()))
 }
 
 #Preview {
     AccountHeader(caption: "Email, Password, Preferences")
-        .environmentObject(Account(MockUserIdPasswordAccountService()))
+        .environment(Account(MockUserIdPasswordAccountService()))
 }
 
 #Preview {
@@ -113,7 +113,7 @@ public struct AccountHeader: View {
             }
         }
     }
-        .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+        .environment(Account(building: details, active: MockUserIdPasswordAccountService()))
 }
 
 #Preview {
@@ -131,7 +131,7 @@ public struct AccountHeader: View {
             }
         }
     }
-    .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+    .environment(Account(building: details, active: MockUserIdPasswordAccountService()))
 }
 
 #Preview {
@@ -146,6 +146,6 @@ public struct AccountHeader: View {
             }
         }
     }
-        .environmentObject(Account(MockUserIdPasswordAccountService()))
+        .environment(Account(MockUserIdPasswordAccountService()))
 }
 #endif

--- a/Sources/SpeziAccount/AccountOverview.swift
+++ b/Sources/SpeziAccount/AccountOverview.swift
@@ -56,7 +56,7 @@ import SwiftUI
 ///     current edit mode of the view. This can be helpful to, e.g., render a custom `Close` Button if the
 ///     view is not editing when presenting the AccountOverview in a sheet.
 public struct AccountOverview<AdditionalSections: View>: View {
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     
     @Binding private var isEditing: Bool
     
@@ -126,12 +126,12 @@ struct AccountOverView_Previews: PreviewProvider {
                 }
             }
         }
-            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
-        
+            .environment(Account(building: details, active: MockUserIdPasswordAccountService()))
+
         NavigationStack {
             AccountOverview()
         }
-            .environmentObject(Account())
+            .environment(Account())
     }
 }
 #endif

--- a/Sources/SpeziAccount/AccountService/AccountService.swift
+++ b/Sources/SpeziAccount/AccountService/AccountService.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/AccountService/Configuration/AccountServiceConfiguration.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/AccountServiceConfiguration.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/AccountService/Configuration/AccountServiceConfigurationKey.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/AccountServiceConfigurationKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A `KnowledgeSource` that implements a configuration option for ``AccountServiceConfiguration``.

--- a/Sources/SpeziAccount/AccountService/Configuration/AccountServiceImage.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/AccountServiceImage.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/AccountService/Configuration/AccountServiceName.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/AccountServiceName.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Spezi
+import SpeziFoundation
 
 
 /// The localized name of an ``AccountService``.

--- a/Sources/SpeziAccount/AccountService/Configuration/FieldValidationRules.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/FieldValidationRules.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SpeziValidation
 
 

--- a/Sources/SpeziAccount/AccountService/Configuration/RequiredAccountKeys.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/RequiredAccountKeys.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// The collection of ``AccountKey``s that are required when using the associated ``AccountService``.

--- a/Sources/SpeziAccount/AccountService/Configuration/UserIdConfiguration.swift
+++ b/Sources/SpeziAccount/AccountService/Configuration/UserIdConfiguration.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -58,7 +58,7 @@ public struct AccountSetup<Header: View, Continue: View>: View {
     private let header: Header
     private let continueButton: Continue
 
-    @EnvironmentObject var account: Account
+    @Environment(Account.self) var account
 
     @State private var setupState: _AccountSetupState = .generic
     @State private var followUpSheet = false
@@ -112,8 +112,8 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                     .frame(maxWidth: .infinity)
             }
         }
-            .onReceive(account.$details) { details in
-                if let details, case .setupShown = setupState {
+            .onChange(of: account.signedIn) { // TODO: ideally react on account.details
+                if let details = account.details, case .setupShown = setupState {
                     let missingKeys = account.configuration.missingRequiredKeys(for: details, includeCollected: details.isNewUser)
 
                     if missingKeys.isEmpty {
@@ -236,14 +236,14 @@ struct AccountView_Previews: PreviewProvider {
     @MainActor static var previews: some View {
         ForEach(accountServicePermutations.indices, id: \.self) { index in
             AccountSetup()
-                .environmentObject(Account(services: accountServicePermutations[index] + [MockSignInWithAppleProvider()]))
+                .environment(Account(services: accountServicePermutations[index] + [MockSignInWithAppleProvider()]))
         }
 
         AccountSetup()
-            .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
+            .environment(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
 
         AccountSetup(state: .setupShown)
-            .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
+            .environment(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
 
         AccountSetup(continue: {
             Button(action: {
@@ -254,7 +254,7 @@ struct AccountView_Previews: PreviewProvider {
             })
             .buttonStyle(.borderedProminent)
         })
-            .environmentObject(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
+            .environment(Account(building: detailsBuilder, active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -113,7 +113,7 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                     .frame(maxWidth: .infinity)
             }
         }
-            .onChange(of: account.signedIn) { // TODO: ideally react on account.details
+            .onChange(of: account.signedIn) {
                 if let details = account.details, case .setupShown = setupState {
                     let missingKeys = account.configuration.missingRequiredKeys(for: details, includeCollected: details.isNewUser)
 

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -53,6 +53,7 @@ public enum _AccountSetupState: EnvironmentKey { // swiftlint:disable:this type_
 ///     }
 /// }
 /// ```
+@MainActor
 public struct AccountSetup<Header: View, Continue: View>: View {
     private let setupCompleteClosure: (AccountDetails) -> Void
     private let header: Header

--- a/Sources/SpeziAccount/AccountSetupViewStyle/AccountSetupViewStyle.swift
+++ b/Sources/SpeziAccount/AccountSetupViewStyle/AccountSetupViewStyle.swift
@@ -26,6 +26,16 @@ public protocol AccountSetupViewStyle {
     /// The associated ``AccountService`` instance.
     var service: Service { get }
 
+    /// A `ViewModifier` that is injected into views with security related operations.
+    ///
+    /// This modifier is injected into views that expose security related operations like changing the password
+    /// or change the user identifier. It is guaranteed that this modifier is not injected twice into the same
+    /// view hierarchy.
+    ///
+    /// - Note: It is advised to implement this as a computed property.
+    var securityRelatedViewModifier: any ViewModifier { get }
+
+
     /// The button label in the list of account services for the ``AccountSetup`` view.
     @ViewBuilder
     func makeServiceButtonLabel() -> ButtonLabel
@@ -41,6 +51,12 @@ public protocol AccountSetupViewStyle {
 
 
 extension AccountSetupViewStyle {
+    /// Default implementation that doesn't modify anything.
+    public var securityRelatedViewModifier: any ViewModifier {
+        NoopModifier()
+    }
+
+
     /// Default service button label using the ``AccountServiceName`` and ``AccountServiceImage`` configurations.
     public func makeServiceButtonLabel() -> some View {
         Group {

--- a/Sources/SpeziAccount/AccountValue/AccountAnchor.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountAnchor.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A `RepositoryAnchor` for ``AccountStorage``.

--- a/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
@@ -21,6 +21,7 @@ extension AccountKey where Value: CustomLocalizedStringResourceConvertible {
 }
 
 
+@MainActor
 extension AccountKey {
     static func emptyDataEntryView<Values: AccountValues>(for values: Values.Type) -> AnyView {
         AnyView(GeneralizedDataEntryView<DataEntry, Values>(initialValue: initialValue.value))

--- a/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/AccountValue/AccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 import XCTRuntimeAssertions
 

--- a/Sources/SpeziAccount/AccountValue/AccountStorage.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountStorage.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A `ValueRepository` that stores `KnowledgeSource`s anchored to the ``AccountAnchor``.

--- a/Sources/SpeziAccount/AccountValue/AccountValues.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountValues.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// An arbitrary collection of account values.

--- a/Sources/SpeziAccount/AccountValue/AccountValuesBuilder.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountValuesBuilder.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import Spezi
+import SpeziFoundation
 
 
 private class RemoveVisitor<Values: AccountValues>: AccountKeyVisitor {

--- a/Sources/SpeziAccount/AccountValue/AccountValuesBuilder.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountValuesBuilder.swift
@@ -86,9 +86,10 @@ private class CopyKeyVisitor<Destination: AccountValues, Source: AccountValues>:
 /// - ``AccountValuesBuilder/build()-pqt5``
 /// - ``AccountValuesBuilder/build(owner:)``
 /// - ``AccountValuesBuilder/build(checking:)``
-public class AccountValuesBuilder<Values: AccountValues>: ObservableObject, AccountValuesCollection {
-    @Published var storage: AccountStorage
-    @Published var defaultValues: AccountStorage
+@Observable
+public class AccountValuesBuilder<Values: AccountValues>: AccountValuesCollection {
+    var storage: AccountStorage
+    var defaultValues: AccountStorage
 
 
     init(from storage: AccountStorage) {

--- a/Sources/SpeziAccount/AccountValue/Collections/AccountDetails.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/AccountDetails.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A typed storage container to easily access any information for the currently signed in user.

--- a/Sources/SpeziAccount/AccountValue/Collections/ModifiedAccountDetails.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/ModifiedAccountDetails.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// Set of ``AccountValues`` that were modified or added.

--- a/Sources/SpeziAccount/AccountValue/Collections/PartialAccountDetails.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/PartialAccountDetails.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// Set of ``AccountValues`` that resembled ``AccountDetails`` but may be incomplete in respect to the

--- a/Sources/SpeziAccount/AccountValue/Collections/RemovedAccountDetails.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/RemovedAccountDetails.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// Set of ``AccountValues`` that were removed providing access to the old values.

--- a/Sources/SpeziAccount/AccountValue/Collections/SignupDetails.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/SignupDetails.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// Set of ``AccountValues`` that were collected at signup to create a new user account.

--- a/Sources/SpeziAccount/AccountValue/Keys/ActiveAccountServiceKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/ActiveAccountServiceKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A `KnowledgeSource` to access the ``AccountService`` associated with the ``AccountDetails``.

--- a/Sources/SpeziAccount/AccountValue/Keys/EmailAddressKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/EmailAddressKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SpeziValidation
 import SwiftUI
 

--- a/Sources/SpeziAccount/AccountValue/Keys/IsNewUserKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/IsNewUserKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 struct IsNewUserKey: KnowledgeSource {

--- a/Sources/SpeziAccount/AccountValue/Keys/PersonNameKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/PersonNameKey.swift
@@ -66,7 +66,7 @@ extension PersonNameKey {
         public typealias Key = PersonNameKey
 
 
-        @EnvironmentObject private var account: Account
+        @Environment(Account.self) private var account
 
         @ValidationState private var givenNameValidation
         @ValidationState private var familyNameValidation

--- a/Sources/SpeziAccount/AccountValue/Keys/UserIdKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/UserIdKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SpeziValidation
 import SwiftUI
 

--- a/Sources/SpeziAccount/AccountValue/RequiredAccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/RequiredAccountKey.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A typed storage key extending ``AccountKey`` for values that are required for every user account if used.

--- a/Sources/SpeziAccount/AccountValue/Visitor/AccountKey+Visitor.swift
+++ b/Sources/SpeziAccount/AccountValue/Visitor/AccountKey+Visitor.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 extension AccountKey {

--- a/Sources/SpeziAccount/AccountValue/Visitor/AccountValueVisitor.swift
+++ b/Sources/SpeziAccount/AccountValue/Visitor/AccountValueVisitor.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 
 
 /// A collection type that is capable of accepting an ``AccountValueVisitor``.

--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Services/Creating your own Account Service.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Services/Creating your own Account Service.md
@@ -81,13 +81,13 @@ The first approach is to provide your ``AccountService`` as is and let the user 
 pass it to the result builder closure of the ``AccountServiceConfiguration/init(name:supportedKeys:configuration:)`` initializer.
 This is the preferred approach for account services that don't require additional setup or rely on any special infrastructure.
 
-If your account service requires additional setup or any infrastructure that relies on other `Component`s you can implement
-your own `Spezi` [Component](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/component) that _provides_ your
-``AccountService`` directly to the ``AccountServiceConfiguration`` component. To do so, declare the `@Provide` property wrapper with a type of
+If your account service requires additional setup or any infrastructure that relies on other `Module`s you can implement
+your own `Spezi` [Module](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module) that _provides_ your
+``AccountService`` directly to the ``AccountServiceConfiguration`` module. To do so, declare the `@Provide` property wrapper with a type of
 `any AccountService` and populate it within your initializer. Below is a code example.
 
 ```swift
-class MyComponent: Component {
+class MyModule: Module {
     @Provide var accountService: any AccountService // you can also use a type of [any AccountService] to provide multiple with a single @Provide
 
     init() {
@@ -100,7 +100,7 @@ class MyComponent: Component {
 }
 ```
 
-> Note: Refer to the [Component Communication](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/component#Communication) documentation
+> Note: Refer to the [Module Communication](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-communication) documentation
     of the `Spezi` framework for more detailed information.
 
 

--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
@@ -26,15 +26,15 @@ The first step is to create a new type that adopts the ``AccountKey`` protocol.
 
 > Note: Refer to the ``RequiredAccountKey`` protocol if you require an account value that is always required to be supplied if configured.
 
-When adopting the protocol, you have to provide the associated [Value](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/knowledgesource/value)
+When adopting the protocol, you have to provide the associated [Value](https://swiftpackageindex.com/stanfordspezi/spezifoundation/documentation/spezifoundation/knowledgesource/value)
 type, a ``AccountKey/name``, a ``AccountKey/category`` and an ``AccountKey/initialValue-6h1oo``.
 The `Value` defines the type of the account value, the `name` is used to textually refer to the account value and 
 the `category` is used to group the account values in UI components (see ``AccountKeyCategory`` for more information).
 The `initialValue` defines the initial value on signup and how it is used. For some types like String a default ``InitialValue/empty(_:)`` implementation is provided.
 
 > Note: The associated type for the value is coming from the underlying 
-    [KnowledgeSource](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/knowledgesource) protocol from the Spezi framework. 
-    Refer to the [Shared Repository](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/shared-repository)
+    [KnowledgeSource](https://swiftpackageindex.com/stanfordspezi/spezifoundation/documentation/spezifoundation/knowledgesource) protocol from the Spezi framework. 
+    Refer to the [Shared Repository](https://swiftpackageindex.com/stanfordspezi/spezifoundation/documentation/spezifoundation/shared-repository)
     documentation for more information.
 
 Below is a code example implementing a simple string-based biography that a user might show on their profile.

--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Handling Account Value Storage.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Handling Account Value Storage.md
@@ -23,7 +23,7 @@ few differences in construction operations, they convey entirely different seman
 
 ``AccountKey``s define an extension to the ``AccountValues`` so account values can be conveniently accessed. For example, the
 ``PersonNameKey`` defines the ``AccountValues/name`` property as an extension to access the name of a person if it exists.
-Otherwise, you can always access the underlying [Shared Repository](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/shared-repository)
+Otherwise, you can always access the underlying [Shared Repository](https://swiftpackageindex.com/stanfordspezi/spezifoundation/documentation/spezifoundation/shared-repository)
 using the ``AccountValues/storage`` property.
 
 ### Iterating through Account Values
@@ -56,7 +56,7 @@ let encoded = details.acceptAll(&visitor)
 ```
 
 > Important: ``AccountValues`` implement the `Collection` protocol and therefore support iteration. However, `Element`s of the collection are of type
-    [AnyRepositoryValue](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/anyrepositoryvalue) as ``AccountValues`` might store
+    [AnyRepositoryValue](https://swiftpackageindex.com/stanfordspezi/spezifoundation/documentation/spezifoundation/anyrepositoryvalue) as ``AccountValues`` might store
     non-``AccountKey`` conforming knowledge sources like the ``ActiveAccountServiceKey``.
 
 ### Iterating through Account Keys

--- a/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
+++ b/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
@@ -14,7 +14,8 @@ import SwiftUI
 
 
 @MainActor
-class AccountOverviewFormViewModel: ObservableObject {
+@Observable
+class AccountOverviewFormViewModel {
     private static var logger: Logger {
         LoggerKey.defaultValue
     }
@@ -27,14 +28,14 @@ class AccountOverviewFormViewModel: ObservableObject {
     private let categorizedAccountKeys: OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]>
 
 
-    let modifiedDetailsBuilder = ModifiedAccountDetails.Builder() // nested ObservableObject, see init
+    let modifiedDetailsBuilder = ModifiedAccountDetails.Builder()
 
-    @Published var presentingCancellationDialog = false
-    @Published var presentingLogoutAlert = false
-    @Published var presentingRemovalAlert = false
+    var presentingCancellationDialog = false
+    var presentingLogoutAlert = false
+    var presentingRemovalAlert = false
 
-    @Published var addedAccountKeys = CategorizedAccountKeys()
-    @Published var removedAccountKeys = CategorizedAccountKeys()
+    var addedAccountKeys = CategorizedAccountKeys()
+    var removedAccountKeys = CategorizedAccountKeys()
 
     var hasUnsavedChanges: Bool {
         !modifiedDetailsBuilder.isEmpty
@@ -44,17 +45,9 @@ class AccountOverviewFormViewModel: ObservableObject {
         .init("ACCOUNT_OVERVIEW_EDIT_DEFAULT_ERROR", bundle: .atURL(from: .module))
     }
 
-    private var anyCancellable: [AnyCancellable] = []
-
 
     init(account: Account) {
         self.categorizedAccountKeys = account.configuration.allCategorized()
-
-        // We forward the objectWillChange publisher. Our `hasUnsavedChanges` is affected by changes to the builder.
-        // Otherwise, changes to the object wouldn't be important.
-        anyCancellable.append(modifiedDetailsBuilder.objectWillChange.sink { [weak self] _ in
-            self?.objectWillChange.send()
-        })
     }
 
 
@@ -210,10 +203,5 @@ class AccountOverviewFormViewModel: ObservableObject {
     func displaysNameDetails() -> Bool {
         categorizedAccountKeys[.credentials]?.contains(where: { $0 == UserIdKey.self }) == true
             || categorizedAccountKeys[.name]?.isEmpty != true
-    }
-
-
-    deinit {
-        anyCancellable.forEach { $0.cancel() }
     }
 }

--- a/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
@@ -13,7 +13,7 @@ struct AccountRequiredModifier<SetupSheet: View>: ViewModifier {
     private let required: Bool
     private let setupSheet: SetupSheet
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     @State private var presentingSheet = false
 

--- a/Sources/SpeziAccount/ViewModifier/AnyViewModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/AnyViewModifier.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+extension ViewModifier {
+    func inject<V: View>(into view: V) -> AnyView {
+        AnyView(view.modifier(self))
+    }
+}
+
+
+extension View {
+    /// Modify the view with an type-erased `ViewModifier`.
+    /// - Parameter modifier: The view modifier.
+    /// - Returns: The modified view.
+    func anyViewModifier(_ modifier: any ViewModifier) -> some View {
+        modifier.inject(into: self)
+    }
+}

--- a/Sources/SpeziAccount/ViewModifier/NoopModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/NoopModifier.swift
@@ -1,0 +1,16 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct NoopModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+    }
+}

--- a/Sources/SpeziAccount/ViewModifier/RequiredValidationModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/RequiredValidationModifier.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 private struct RequiredValidationModifier<Key: AccountKey, Values: AccountValues>: ViewModifier {
-    @EnvironmentObject private var detailsBuilder: AccountValuesBuilder<Values>
+    @Environment(AccountValuesBuilder<Values>.self) private var detailsBuilder
 
     @ValidationState private var validation
     @ValidationState private var innerValidation

--- a/Sources/SpeziAccount/ViewModifier/VerifyRequiredAccountDetailsModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/VerifyRequiredAccountDetailsModifier.swift
@@ -22,7 +22,7 @@ private struct FollowUpSession: Identifiable {
 struct VerifyRequiredAccountDetailsModifier: ViewModifier {
     private let verify: Bool
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     @SceneStorage("edu.stanford.spezi-account.startup-account-check") private var verifiedAccount = false
     @State private var followUpSession: FollowUpSession?

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -13,7 +13,7 @@ struct AccountKeyOverviewRow: View {
     private let accountDetails: AccountDetails
     private let accountKey: any AccountKey.Type
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     @Environment(\.editMode) private var editMode
 
     @ObservedObject private var model: AccountOverviewFormViewModel
@@ -92,6 +92,7 @@ struct AccountKeyEditRow_Previews: PreviewProvider {
         if let details = account.details {
             AccountKeyOverviewRow(details: details, for: GenderIdentityKey.self, model: model)
                 .injectEnvironmentObjects(service: details.accountService, model: model)
+                .environment(account)
         }
     }
 }

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -12,11 +12,10 @@ import SwiftUI
 struct AccountKeyOverviewRow: View {
     private let accountDetails: AccountDetails
     private let accountKey: any AccountKey.Type
+    private let model: AccountOverviewFormViewModel
 
     @Environment(Account.self) private var account
     @Environment(\.editMode) private var editMode
-
-    @ObservedObject private var model: AccountOverviewFormViewModel
 
     var body: some View {
         if editMode?.wrappedValue.isEditing == true {
@@ -67,6 +66,7 @@ struct AccountKeyOverviewRow: View {
     }
 
 
+    @MainActor
     func isDeleteDisabled(for key: any AccountKey.Type) -> Bool {
         if accountDetails.contains(key) && !model.removedAccountKeys.contains(key) {
             return account.configuration[key]?.requirement == .required
@@ -86,7 +86,7 @@ struct AccountKeyEditRow_Previews: PreviewProvider {
 
     static let account = Account(building: details, active: MockUserIdPasswordAccountService())
 
-    @StateObject private static var model = AccountOverviewFormViewModel(account: account)
+    @State private static var model = AccountOverviewFormViewModel(account: account)
 
     static var previews: some View {
         if let details = account.details {

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -21,8 +21,8 @@ struct AccountOverviewSections<AdditionalSections: View>: View {
         accountDetails.accountService
     }
     
-    @EnvironmentObject private var account: Account
-    
+    @Environment(Account.self) private var account
+
     @Environment(\.logger) private var logger
     @Environment(\.editMode) private var editMode
     @Environment(\.dismiss) private var dismiss
@@ -283,7 +283,7 @@ struct AccountOverviewSections_Previews: PreviewProvider {
                 }
             }
         }
-            .environmentObject(Account(building: details, active: MockUserIdPasswordAccountService()))
+            .environment(Account(building: details, active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -13,6 +13,7 @@ import SwiftUI
 
 
 /// A internal subview of ``AccountOverview`` that expects to be embedded into a `Form`.
+@MainActor
 struct AccountOverviewSections<AdditionalSections: View>: View {
     let additionalSections: AdditionalSections
     private let accountDetails: AccountDetails
@@ -27,7 +28,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View {
     @Environment(\.editMode) private var editMode
     @Environment(\.dismiss) private var dismiss
     
-    @StateObject private var model: AccountOverviewFormViewModel
+    @State private var model: AccountOverviewFormViewModel
     @ValidationState private var validation
 
     @State private var viewState: ViewState = .idle
@@ -213,7 +214,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View {
         @ViewBuilder additionalSections: (() -> AdditionalSections) = { EmptyView() }
     ) {
         self.accountDetails = accountDetails
-        self._model = StateObject(wrappedValue: AccountOverviewFormViewModel(account: account))
+        self._model = State(wrappedValue: AccountOverviewFormViewModel(account: account))
         self._isEditing = isEditing
         self.additionalSections = additionalSections()
     }

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -14,6 +14,10 @@ struct NameOverview: View {
     private let model: AccountOverviewFormViewModel
     private let accountDetails: AccountDetails
 
+    private var service: any AccountService {
+        accountDetails.accountService
+    }
+
     @Environment(Account.self) private var account
 
 
@@ -37,7 +41,7 @@ struct NameOverview: View {
                                 Text("VALUE_ADD \(wrapper.accountKey.name)", bundle: .module)
                                     .foregroundColor(.secondary)
                             }
-                            .accessibilityElement(children: .combine)
+                                .accessibilityElement(children: .combine)
                         }
                     }
                 } header: {
@@ -48,6 +52,7 @@ struct NameOverview: View {
                 }
             }
         }
+            .anyViewModifier(service.viewStyle.securityRelatedViewModifier)
             .navigationTitle(model.accountIdentifierLabel(configuration: account.configuration, userIdType: accountDetails.userIdType))
             .navigationBarTitleDisplayMode(.inline)
             .injectEnvironmentObjects(service: accountDetails.accountService, model: model)

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct NameOverview: View {
     private let accountDetails: AccountDetails
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     @ObservedObject private var model: AccountOverviewFormViewModel
 
@@ -83,14 +83,14 @@ struct NameOverview_Previews: PreviewProvider {
                 NameOverview(model: model, details: details)
             }
         }
-            .environmentObject(account)
+            .environment(account)
 
         NavigationStack {
             if let details = accountWithoutName.details {
                 NameOverview(model: model, details: details)
             }
         }
-        .environmentObject(accountWithoutName)
+            .environment(accountWithoutName)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -11,11 +11,11 @@ import SwiftUI
 
 
 struct NameOverview: View {
+    private let model: AccountOverviewFormViewModel
     private let accountDetails: AccountDetails
 
     @Environment(Account.self) private var account
 
-    @ObservedObject private var model: AccountOverviewFormViewModel
 
     var body: some View {
         Form {
@@ -75,7 +75,7 @@ struct NameOverview_Previews: PreviewProvider {
     static let accountWithoutName = Account(building: detailsWithoutName, active: MockUserIdPasswordAccountService())
 
     // be aware, modifications won't be displayed due to declaration in PreviewProvider that do not trigger an UI update
-    @StateObject static var model = AccountOverviewFormViewModel(account: account)
+    @State static var model = AccountOverviewFormViewModel(account: account)
 
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -46,6 +46,7 @@ struct PasswordChangeSheet: View {
                     .environment(\.defaultErrorDescription, model.defaultErrorDescription)
             }
                 .viewStateAlert(state: $viewState)
+                .anyViewModifier(service.viewStyle.securityRelatedViewModifier)
                 .navigationTitle(Text("CHANGE_PASSWORD", bundle: .module))
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -11,8 +11,10 @@ import SpeziViews
 import SwiftUI
 
 
+@MainActor
 struct PasswordChangeSheet: View {
     private let accountDetails: AccountDetails
+    private let model: AccountOverviewFormViewModel
 
     private var service: any AccountService {
         accountDetails.accountService
@@ -22,7 +24,6 @@ struct PasswordChangeSheet: View {
     @Environment(\.logger) private var logger
     @Environment(\.dismiss) private var dismiss
 
-    @ObservedObject private var model: AccountOverviewFormViewModel
     @ValidationState private var validation
 
     @State private var viewState: ViewState = .idle
@@ -137,7 +138,7 @@ struct PasswordChangeSheet_Previews: PreviewProvider {
     static let account = Account(building: details, active: MockUserIdPasswordAccountService())
 
     // be aware, modifications won't be displayed due to declaration in PreviewProvider that do not trigger an UI update
-    @StateObject static var model = AccountOverviewFormViewModel(account: account)
+    @State static var model = AccountOverviewFormViewModel(account: account)
 
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -145,7 +145,7 @@ struct PasswordChangeSheet_Previews: PreviewProvider {
                 PasswordChangeSheet(model: model, details: details)
             }
         }
-        .environmentObject(account)
+        .environment(account)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
@@ -18,7 +18,7 @@ struct SecurityOverview: View {
     }
 
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     @ObservedObject private var model: AccountOverviewFormViewModel
 
     @State private var viewState: ViewState = .idle
@@ -90,7 +90,7 @@ struct SecurityOverview_Previews: PreviewProvider {
                 SecurityOverview(model: model, details: details)
             }
         }
-            .environmentObject(account)
+            .environment(account)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct SecurityOverview: View {
     private let accountDetails: AccountDetails
+    private let model: AccountOverviewFormViewModel
 
     private var service: any AccountService {
         accountDetails.accountService
@@ -19,7 +20,6 @@ struct SecurityOverview: View {
 
 
     @Environment(Account.self) private var account
-    @ObservedObject private var model: AccountOverviewFormViewModel
 
     @State private var viewState: ViewState = .idle
     @State private var presentingPasswordChangeSheet = false
@@ -82,7 +82,7 @@ struct SecurityOverview_Previews: PreviewProvider {
     static let account = Account(building: details, active: MockUserIdPasswordAccountService())
 
     // be aware, modifications won't be displayed due to declaration in PreviewProvider that do not trigger an UI update
-    @StateObject static var model = AccountOverviewFormViewModel(account: account)
+    @State static var model = AccountOverviewFormViewModel(account: account)
 
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
@@ -11,7 +11,9 @@ import SpeziViews
 import SwiftUI
 
 
+@MainActor
 struct SingleEditView<Key: AccountKey>: View {
+    private let model: AccountOverviewFormViewModel
     private let accountDetails: AccountDetails
 
     private var service: any AccountService {
@@ -22,7 +24,6 @@ struct SingleEditView<Key: AccountKey>: View {
     @Environment(\.logger) private var logger
     @Environment(\.dismiss) private var dismiss
 
-    @ObservedObject private var model: AccountOverviewFormViewModel
     @ValidationState private var validation
 
     @State private var viewState: ViewState = .idle
@@ -88,7 +89,7 @@ struct SingleEditView_Previews: PreviewProvider {
     static let account = Account(building: details, active: MockUserIdPasswordAccountService())
 
     // be aware, modifications won't be displayed due to declaration in PreviewProvider that do not trigger an UI update
-    @StateObject static var model = AccountOverviewFormViewModel(account: account)
+    @State static var model = AccountOverviewFormViewModel(account: account)
 
     static var previews: some View {
         NavigationStack {

--- a/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
@@ -96,7 +96,7 @@ struct SingleEditView_Previews: PreviewProvider {
                 SingleEditView<PersonNameKey>(model: model, details: details)
             }
         }
-            .environmentObject(account)
+            .environment(account)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/View+AccountOverviewObjects.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/View+AccountOverviewObjects.swift
@@ -13,6 +13,6 @@ extension View {
     func injectEnvironmentObjects(service: any AccountService, model: AccountOverviewFormViewModel) -> some View {
         self
             .environment(\.accountServiceConfiguration, service.configuration)
-            .environmentObject(model.modifiedDetailsBuilder)
+            .environment(model.modifiedDetailsBuilder)
     }
 }

--- a/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
@@ -14,7 +14,7 @@ import SwiftUI
 /// This view expects a ``Account`` object to be in the environment to dynamically
 /// present the appropriate subtitle.
 public struct DefaultAccountSetupHeader: View {
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     @Environment(\._accountSetupState) private var setupState
 
     public var body: some View {
@@ -46,10 +46,10 @@ public struct DefaultAccountSetupHeader: View {
 struct DefaultAccountSetupHeader_Previews: PreviewProvider {
     static var previews: some View {
         DefaultAccountSetupHeader()
-            .environmentObject(Account())
+            .environment(Account())
 
         DefaultAccountSetupHeader()
-            .environmentObject(Account(building: .init().set(\.userId, value: "myUser"), active: MockUserIdPasswordAccountService()))
+            .environment(Account(building: .init().set(\.userId, value: "myUser"), active: MockUserIdPasswordAccountService()))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
@@ -23,7 +23,7 @@ struct FollowUpInfoSheet: View {
     @Environment(\.logger) private var logger
     @Environment(\.dismiss) private var dismiss
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     @StateObject private var detailsBuilder = ModifiedAccountDetails.Builder()
     @ValidationState private var validation
@@ -150,7 +150,7 @@ struct FollowUpInfoSheet_Previews: PreviewProvider {
                 FollowUpInfoSheet(details: details, requiredKeys: [PersonNameKey.self])
             }
         }
-            .environmentObject(account)
+            .environment(account)
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
@@ -12,6 +12,7 @@ import SpeziViews
 import SwiftUI
 
 
+@MainActor
 struct FollowUpInfoSheet: View {
     private let accountDetails: AccountDetails
     private let accountKeyByCategory: OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]>
@@ -25,7 +26,7 @@ struct FollowUpInfoSheet: View {
 
     @Environment(Account.self) private var account
 
-    @StateObject private var detailsBuilder = ModifiedAccountDetails.Builder()
+    @State private var detailsBuilder = ModifiedAccountDetails.Builder()
     @ValidationState private var validation
 
     @State private var viewState: ViewState = .idle
@@ -89,7 +90,7 @@ struct FollowUpInfoSheet: View {
             SignupSectionsView(for: ModifiedAccountDetails.self, service: service, sections: accountKeyByCategory)
                 .environment(\.accountServiceConfiguration, service.configuration)
                 .environment(\.accountViewType, .signup)
-                .environmentObject(detailsBuilder)
+                .environment(detailsBuilder)
                 .focused($isFocused)
 
             AsyncButton(state: $viewState, action: completeButtonAction) {

--- a/Sources/SpeziAccount/Views/AccountSetup/SignupSectionsView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/SignupSectionsView.swift
@@ -24,7 +24,7 @@ struct SignupSectionsView<Storage: AccountValues>: View {
     private let sections: OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]>
     private let storageType: Storage.Type
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     var body: some View {
         // OrderedDictionary `elements` conforms to RandomAccessCollection so we can directly use it
@@ -67,7 +67,7 @@ struct SignupSectionsView_Previews: PreviewProvider {
                 .name: [PersonNameKey.self]
             ])
         }
-            .environmentObject(Account(service))
+            .environment(Account(service))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/DataDisplay/DataDisplayView.swift
+++ b/Sources/SpeziAccount/Views/DataDisplay/DataDisplayView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/Views/DataDisplay/LocalizableStringBasedDisplayView.swift
+++ b/Sources/SpeziAccount/Views/DataDisplay/LocalizableStringBasedDisplayView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/Views/DataDisplay/StringBasedDisplayView.swift
+++ b/Sources/SpeziAccount/Views/DataDisplay/StringBasedDisplayView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/Views/DataEntry/DataEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/DataEntryView.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+import SpeziFoundation
 import SwiftUI
 
 

--- a/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
 import SpeziValidation
 import SwiftUI
 

--- a/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
@@ -31,7 +31,7 @@ public struct GeneralizedDataEntryView<Wrapped: DataEntryView, Values: AccountVa
 
     @Environment(Account.self) private var account
 
-    @EnvironmentObject private var detailsBuilder: AccountValuesBuilder<Values>
+    @Environment(AccountValuesBuilder<Values>.self) private var detailsBuilder
 
     @Environment(\.accountServiceConfiguration) private var configuration
     @Environment(\.accountViewType) private var viewType

--- a/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/GeneralizedDataEntryView.swift
@@ -29,7 +29,7 @@ public struct GeneralizedDataEntryView<Wrapped: DataEntryView, Values: AccountVa
         "DataHook-\(Wrapped.Key.self)"
     }
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     @EnvironmentObject private var detailsBuilder: AccountValuesBuilder<Values>
 

--- a/Sources/SpeziAccount/Views/Fields/DateOfBirthPicker.swift
+++ b/Sources/SpeziAccount/Views/Fields/DateOfBirthPicker.swift
@@ -15,7 +15,7 @@ public struct DateOfBirthPicker: DataEntryView {
 
     private let titleLocalization: LocalizedStringResource
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     @Environment(\.accountViewType) private var viewType
 
     @Binding private var date: Date
@@ -133,18 +133,18 @@ struct DateOfBirthPicker_Previews: PreviewProvider {
     static var previews: some View {
         // preview entering new data.
         Preview()
-            .environmentObject(Account(MockUserIdPasswordAccountService()))
+            .environment(Account(MockUserIdPasswordAccountService()))
             .environment(\.accountViewType, .signup)
 
         // preview entering new data but displaying existing data.
         Preview()
-            .environmentObject(Account(MockUserIdPasswordAccountService()))
+            .environment(Account(MockUserIdPasswordAccountService()))
             .environment(\.accountViewType, .overview(mode: .existing))
 
         // preview entering new data but required.
         Preview()
+            .environment(Account(MockUserIdPasswordAccountService(), configuration: [.requires(\.dateOfBirth)]))
             .environment(\.accountViewType, .signup)
-            .environmentObject(Account(MockUserIdPasswordAccountService(), configuration: [.requires(\.dateOfBirth)]))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/SignupForm.swift
+++ b/Sources/SpeziAccount/Views/SignupForm.swift
@@ -50,7 +50,7 @@ public struct SignupForm<Service: AccountService, Header: View>: View {
     @Environment(Account.self) private var account
     @Environment(\.dismiss) private var dismiss
 
-    @StateObject private var signupDetailsBuilder = SignupDetails.Builder()
+    @State private var signupDetailsBuilder = SignupDetails.Builder()
     @ValidationState private var validation
 
     @State private var viewState: ViewState = .idle
@@ -107,14 +107,14 @@ public struct SignupForm<Service: AccountService, Header: View>: View {
             }
     }
 
-    @ViewBuilder var form: some View {
+    @MainActor @ViewBuilder var form: some View {
         Form {
             header
 
             SignupSectionsView(for: SignupDetails.self, service: service, sections: accountKeyByCategory)
                 .environment(\.accountServiceConfiguration, service.configuration)
                 .environment(\.accountViewType, .signup)
-                .environmentObject(signupDetailsBuilder)
+                .environment(signupDetailsBuilder)
 
             AsyncButton(state: $viewState, action: signupButtonAction) {
                 Text("UP_SIGNUP", bundle: .module)
@@ -143,6 +143,7 @@ public struct SignupForm<Service: AccountService, Header: View>: View {
     }
 
 
+    @MainActor
     private func signupButtonAction() async throws {
         guard validation.validateSubviews() else {
             return

--- a/Sources/SpeziAccount/Views/SignupForm.swift
+++ b/Sources/SpeziAccount/Views/SignupForm.swift
@@ -47,7 +47,7 @@ public struct SignupForm<Service: AccountService, Header: View>: View {
     private let service: Service
     private let header: Header
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
     @Environment(\.dismiss) private var dismiss
 
     @StateObject private var signupDetailsBuilder = SignupDetails.Builder()
@@ -168,7 +168,7 @@ struct DefaultUserIdPasswordSignUpView_Previews: PreviewProvider {
         NavigationStack {
             SignupForm(using: accountService)
         }
-            .environmentObject(Account(accountService))
+            .environment(Account(accountService))
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
@@ -28,7 +28,7 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
         service.configuration.userIdConfiguration
     }
 
-    @EnvironmentObject private var account: Account
+    @Environment(Account.self) private var account
 
     // for login we do all checks server-side. Except that we don't pass empty values.
     @ValidationState private var validation
@@ -128,6 +128,7 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
     }
 
 
+    @MainActor
     private func loginButtonAction() async throws {
         guard validation.validateSubviews() else {
             return
@@ -146,6 +147,6 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
     return NavigationStack {
         UserIdPasswordEmbeddedView(using: accountService)
     }
-        .environmentObject(Account(accountService))
+        .environment(Account(accountService))
 }
 #endif

--- a/Sources/SpeziAccount/Views/UserIdPasswordPrimaryView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordPrimaryView.swift
@@ -54,7 +54,7 @@ struct DefaultUserIdPasswordPrimaryView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             UserIdPasswordPrimaryView(using: accountService)
-                .environmentObject(Account(accountService))
+                .environment(Account(accountService))
         }
     }
 }

--- a/Sources/SpeziAccount/Views/UserIdPasswordResetView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordResetView.swift
@@ -137,14 +137,14 @@ struct DefaultUserIdPasswordResetView_Previews: PreviewProvider {
             UserIdPasswordResetView(using: accountService) {
                 SuccessfulPasswordResetView()
             }
-                .environmentObject(Account(accountService))
+                .environment(Account(accountService))
         }
 
         NavigationStack {
             UserIdPasswordResetView(using: accountService, requestSubmitted: true) {
                 SuccessfulPasswordResetView()
             }
-                .environmentObject(Account(accountService))
+                .environment(Account(accountService))
         }
     }
 }

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -12,12 +12,13 @@ import SpeziViews
 import SwiftUI
 
 
+@MainActor
 struct AccountTestsView: View {
     @Environment(\.features) var features
     
-    @EnvironmentObject var account: Account
-    @EnvironmentObject var standard: TestStandard
-    
+    @Environment(Account.self) var account: Account
+    @Environment(TestStandard.self) var standard
+
     @State var showSetup = false
     @State var showOverview = false
     @State var isEditing = false
@@ -133,13 +134,13 @@ struct AccountTestsView_Previews: PreviewProvider {
     
     static var previews: some View {
         AccountTestsView()
-            .environmentObject(Account(TestAccountService(.emailAddress)))
-        
+            .environment(Account(TestAccountService(.emailAddress)))
+
         AccountTestsView()
-            .environmentObject(Account(building: details, active: TestAccountService(.emailAddress)))
-        
+            .environment(Account(building: details, active: TestAccountService(.emailAddress)))
+
         AccountTestsView()
-            .environmentObject(Account())
+            .environment(Account())
     }
 }
 #endif

--- a/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTests/AccountTestsView.swift
@@ -134,10 +134,10 @@ struct AccountTestsView_Previews: PreviewProvider {
     
     static var previews: some View {
         AccountTestsView()
-            .environment(Account(TestAccountService(.emailAddress)))
+            .environment(Account(TestAccountService(TestAlertModel(), .emailAddress)))
 
         AccountTestsView()
-            .environment(Account(building: details, active: TestAccountService(.emailAddress)))
+            .environment(Account(building: details, active: TestAccountService(TestAlertModel(), .emailAddress)))
 
         AccountTestsView()
             .environment(Account())

--- a/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
@@ -15,23 +15,29 @@ import SpeziAccount
 final class TestAccountConfiguration: Module {
     @Provide var accountServices: [any AccountService]
 
+    @Model var testModel: TestAlertModel
+
     init(features: Features) {
+        let model = TestAlertModel()
+
         switch features.serviceType {
         case .mail:
-            accountServices = [TestAccountService(.emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName)]
+            accountServices = [TestAccountService(model, .emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName)]
         case .both:
             accountServices = [
-                TestAccountService(.emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName),
-                TestAccountService(.username)
+                TestAccountService(model, .emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName),
+                TestAccountService(model, .username)
             ]
         case .withIdentityProvider:
             accountServices = [
-                TestAccountService(.emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName),
+                TestAccountService(model, .emailAddress, defaultAccount: features.defaultCredentials, noName: features.noName),
                 MockSignInWithAppleProvider()
             ]
         case .empty:
             accountServices = []
         }
+
+        testModel = model
     }
 
     func configure() {

--- a/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAccountConfiguration.swift
@@ -12,7 +12,7 @@ import Spezi
 import SpeziAccount
 
 
-final class TestAccountConfiguration: Component {
+final class TestAccountConfiguration: Module {
     @Provide var accountServices: [any AccountService]
 
     init(features: Features) {

--- a/Tests/UITests/TestApp/AccountTests/TestAlertModifier.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAlertModifier.swift
@@ -1,0 +1,39 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+@Observable
+final class TestAlertModel: Sendable {
+    var presentingAlert = false
+    var continuation: CheckedContinuation<Void, Never>?
+}
+
+
+struct TestAlertModifier: ViewModifier {
+    @Environment(TestAlertModel.self) var model
+
+    var isPresented: Binding<Bool> {
+        Binding {
+            model.presentingAlert
+        } set: { newValue in
+            model.presentingAlert = newValue
+        }
+    }
+
+
+    func body(content: Content) -> some View {
+        content
+            .alert("Security Alert", isPresented: isPresented, presenting: model.continuation) { continuation in
+                Button("Dismiss") {
+                    continuation.resume()
+                }
+            }
+    }
+}

--- a/Tests/UITests/TestApp/AccountTests/TestStandard.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestStandard.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 
 // mock implementation of the AccountStorageStandard
-actor TestStandard: AccountStorageStandard, AccountNotifyStandard, ObservableObject, ObservableObjectProvider {
+actor TestStandard: AccountStorageStandard, AccountNotifyStandard, EnvironmentAccessible {
     @MainActor @Published var deleteNotified = false
 
     var records: [AdditionalRecordId: PartialAccountDetails.Builder] = [:]

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -194,6 +194,9 @@ final class AccountOverviewTests: XCTestCase {
         overview.app.typeText("tum.de") // we still have keyboard focus
         overview.app.dismissKeyboard()
         overview.tap(button: "Done")
+
+        XCTAssertTrue(app.alerts["Security Alert"].buttons["Dismiss"].waitForExistence(timeout: 2.0))
+        app.alerts["Security Alert"].buttons["Dismiss"].tap()
         sleep(3)
 
         overview.verifyExistence(text: "lelandstanford@tum.de")
@@ -268,6 +271,9 @@ final class AccountOverviewTests: XCTestCase {
         overview.app.typeText("6789")
 
         overview.tap(button: "Done")
+
+        XCTAssertTrue(app.alerts["Security Alert"].buttons["Dismiss"].waitForExistence(timeout: 2.0))
+        app.alerts["Security Alert"].buttons["Dismiss"].tap()
         sleep(2)
 
         XCTAssertFalse(overview.secureTextFields["enter password"].waitForExistence(timeout: 2.0))

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -574,6 +574,120 @@
 			};
 			name = Release;
 		};
+		A94FDCE12AFC4A86008026CE /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Test;
+		};
+		A94FDCE22AFC4A86008026CE /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = 637867499T;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TestApp/Info.plist;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.account.testapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Test;
+		};
+		A94FDCE32AFC4A86008026CE /* Test */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 637867499T;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.spezi.account.testappuitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = TestApp;
+			};
+			name = Test;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -581,6 +695,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B428F5F386007C25D6 /* Debug */,
+				A94FDCE12AFC4A86008026CE /* Test */,
 				2F6D13B528F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -590,6 +705,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13B728F5F386007C25D6 /* Debug */,
+				A94FDCE22AFC4A86008026CE /* Test */,
 				2F6D13B828F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -599,6 +715,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F6D13BD28F5F386007C25D6 /* Debug */,
+				A94FDCE32AFC4A86008026CE /* Test */,
 				2F6D13BE28F5F386007C25D6 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2FAD38C02A455FC200E79ED1 /* SpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FAD38BF2A455FC200E79ED1 /* SpeziAccount */; };
 		A969240F2A9A198800E2128B /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = A969240E2A9A198800E2128B /* ArgumentParser */; };
 		A96924112A9A2E7800E2128B /* TestAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96924102A9A2E7800E2128B /* TestAccountService.swift */; };
+		A99D25052AFCB7AD002CC42A /* TestAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99D25042AFCB7AD002CC42A /* TestAlertModifier.swift */; };
 		A9B6E3F72A9B6F5B0008B232 /* AccountSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3F62A9B6F5B0008B232 /* AccountSetupTests.swift */; };
 		A9B6E3F92A9B6F660008B232 /* AccountOverviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3F82A9B6F660008B232 /* AccountOverviewTests.swift */; };
 		A9B6E3FB2A9B70360008B232 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3FA2A9B70360008B232 /* Defaults.swift */; };
@@ -60,6 +61,7 @@
 		2FE750C92A8720CE00723EAE /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 		636D985F2AF188E00020B8BC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A96924102A9A2E7800E2128B /* TestAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAccountService.swift; sourceTree = "<group>"; };
+		A99D25042AFCB7AD002CC42A /* TestAlertModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAlertModifier.swift; sourceTree = "<group>"; };
 		A9B6E3F62A9B6F5B0008B232 /* AccountSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupTests.swift; sourceTree = "<group>"; };
 		A9B6E3F82A9B6F660008B232 /* AccountOverviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountOverviewTests.swift; sourceTree = "<group>"; };
 		A9B6E3FA2A9B70360008B232 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
@@ -99,6 +101,7 @@
 		2F027C9629D6C63300234098 /* AccountTests */ = {
 			isa = PBXGroup;
 			children = (
+				A99D25042AFCB7AD002CC42A /* TestAlertModifier.swift */,
 				2F027C7B29D6C29B00234098 /* AccountTestsView.swift */,
 				2F027C7A29D6C29B00234098 /* MockAccountServiceError.swift */,
 				2F027C7E29D6C29B00234098 /* TestAccountConfiguration.swift */,
@@ -313,6 +316,7 @@
 			files = (
 				2F027C8629D6C2AD00234098 /* AccountTestsView.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
+				A99D25052AFCB7AD002CC42A /* TestAlertModifier.swift in Sources */,
 				2F027C8829D6C2AD00234098 /* MockAccountServiceError.swift in Sources */,
 				A9EE7D2A2A3359E800C2B9A9 /* Features.swift in Sources */,
 				2F027C9529D6C63100234098 /* TestAppDelegate.swift in Sources */,

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -22,7 +22,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">


### PR DESCRIPTION
# Upgrade to new Spezi and SpeziFoundation frameworks

## :recycle: Current situation & Problem
This PR updates SpeziAccount to the latest changes of the `Spezi` and `SpeziFoundation` frameworks. Additionally, we migrate away from ObservableObject to the new Observable framework.


## :gear: Release Notes 
 
* Upgrade Spezi to `0.8.0`
* Move to `@Observable`.

## :books: Documentation
--


## :white_check_mark: Testing
--
## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
