### PR TITLE
Inject security related modifier in main overview screen

### DIFF
--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -125,6 +125,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View {
                 // sync the edit mode with the outer view
                 isEditing = newValue
             }
+            .anyViewModifier(service.viewStyle.securityRelatedViewModifier) // for delete action
 
         defaultSections
         


### PR DESCRIPTION
# Inject security related modifier in main overview screen

## :recycle: Current situation & Problem
Projects like SpeziFirebase need to verify authentication credentials on security related operations. This was already implemented in #36 for the SingleEditRow and the SecurityOverview. We forgot to identity, that the account deletion is also considered security sensitive. Therefore, we inject the same modifier in the primary AccountOverview view.

This PR is required for https://github.com/StanfordSpezi/SpeziFirebase/pull/23 to be merged.


## :gear: Release Notes 
* Inject security related modifiers in the AccountOverview


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
