### PR TITLE
Do not inject Account modifiers if not enabled

### DIFF
--- a/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
@@ -57,6 +57,7 @@ extension View {
     ///   - setupSheet: The view that is presented if no account was detected. You may present the ``AccountSetup`` view here.
     ///     This view is directly used with the standard SwiftUI sheet modifier.
     /// - Returns: The modified view.
+    @ViewBuilder
     public func accountRequired<SetupSheet: View>(_ required: Bool = true, @ViewBuilder setupSheet: () -> SetupSheet) -> some View {
         if required {
             modifier(AccountRequiredModifier(setupSheet: setupSheet))

--- a/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 
 struct AccountRequiredModifier<SetupSheet: View>: ViewModifier {
-    private let required: Bool
     private let setupSheet: SetupSheet
 
     @Environment(Account.self) private var account
@@ -18,34 +17,29 @@ struct AccountRequiredModifier<SetupSheet: View>: ViewModifier {
     @State private var presentingSheet = false
 
 
-    init(required: Bool, @ViewBuilder setupSheet: () -> SetupSheet) {
-        self.required = required
+    init(@ViewBuilder setupSheet: () -> SetupSheet) {
         self.setupSheet = setupSheet()
     }
 
 
     func body(content: Content) -> some View {
-        if required {
-            content
-                .onChange(of: [account.signedIn, presentingSheet]) {
-                    if !account.signedIn && !presentingSheet {
-                        presentingSheet = true
-                    }
+        content
+            .onChange(of: [account.signedIn, presentingSheet]) {
+                if !account.signedIn && !presentingSheet {
+                    presentingSheet = true
                 }
-                .task {
-                    try? await Task.sleep(for: .milliseconds(500))
-                    if !account.signedIn {
-                        presentingSheet = true
-                    }
+            }
+            .task {
+                try? await Task.sleep(for: .milliseconds(500))
+                if !account.signedIn {
+                    presentingSheet = true
                 }
-                .sheet(isPresented: $presentingSheet) {
-                    setupSheet
-                        .interactiveDismissDisabled(true)
-                }
-                .environment(\.accountRequired, true)
-        } else {
-            content
-        }
+            }
+            .sheet(isPresented: $presentingSheet) {
+                setupSheet
+                    .interactiveDismissDisabled(true)
+            }
+            .environment(\.accountRequired, true)
     }
 }
 
@@ -63,7 +57,11 @@ extension View {
     ///   - setupSheet: The view that is presented if no account was detected. You may present the ``AccountSetup`` view here.
     ///     This view is directly used with the standard SwiftUI sheet modifier.
     /// - Returns: The modified view.
-    public func accountRequired<SetupSheet: View>(_ required: Bool, @ViewBuilder setupSheet: () -> SetupSheet) -> some View {
-        modifier(AccountRequiredModifier(required: required, setupSheet: setupSheet))
+    public func accountRequired<SetupSheet: View>(_ required: Bool = true, @ViewBuilder setupSheet: () -> SetupSheet) -> some View {
+        if required {
+            modifier(AccountRequiredModifier(setupSheet: setupSheet))
+        } else {
+            self
+        }
     }
 }


### PR DESCRIPTION
# Do not inject Account modifiers if not enabled

## :recycle: Current situation & Problem
With the upgrade to Observable the `@Environment` property wrapper behaves differently to the `@EnvironmentObjet` property wrapper. The two property wrappers behave differently when there is no object in the environment. While `@EnvironmentObject` results in a runtime crash upon access, `@Environment` crashes as soon as the view is getting rendered.

To achieve maximum compatibility, we changed how the `accountRequired(_:setupSheet:)` and `verifyRequiredAccountDetails(_:)` are implemented, to avoid a situation where we request access to the `Account` object when it is not available. This allows us to use those modifiers with greater flexibility.

## :gear: Release Notes 
* Allow  `accountRequired(_:setupSheet:)` and `verifyRequiredAccountDetails(_:)` modifiers to be used (in disabled state) if Account is not configured.


## :books: Documentation
This is implementation details which is not documented.

## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
