### PR TITLE
Restore functionality of the storage standard

### DIFF
--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -205,7 +205,7 @@ public final class Account: Sendable {
 
         var details = details
 
-        if isNewUser {
+        if isNewUser { // mark the account details to be from a new user
             details.patchIsNewUser(true)
         }
 
@@ -227,6 +227,7 @@ public final class Account: Sendable {
             )
         }
 
+        // Check if the account service is wrapped with a storage standard. If that's the case, contact them about the signup!
         if let standardBacked = details.accountService as? any _StandardBacked,
            let storageStandard = standardBacked.standard as? any AccountStorageStandard {
             let recordId = AdditionalRecordId(serviceId: standardBacked.backedId, accountId: details.accountId)

--- a/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
+++ b/Sources/SpeziAccount/AccountService/Wrapper/StandardBacked.swift
@@ -49,7 +49,11 @@ extension _StandardBacked {
     }
 
     /// Default implementation.
-    public func preUserDetailsSupply(recordId: AdditionalRecordId) async throws {}
+    public func preUserDetailsSupply(recordId: AdditionalRecordId) async throws {
+        if let nestedBacked = accountService as? any _StandardBacked {
+            try await nestedBacked.preUserDetailsSupply(recordId: recordId)
+        }
+    }
 }
 
 

--- a/Sources/SpeziAccount/AccountSetupViewStyle/AccountSetupViewStyle.swift
+++ b/Sources/SpeziAccount/AccountSetupViewStyle/AccountSetupViewStyle.swift
@@ -12,9 +12,6 @@ import SwiftUI
 
 /// A view style defining UI components for an associated ``AccountService``.
 public protocol AccountSetupViewStyle {
-    /// The associated ``AccountService``.
-    associatedtype Service: AccountService
-
     /// The button label rendered in the list of account services in ``AccountSetup``
     associatedtype ButtonLabel: View
     /// The primary view that is opened as the destination of the ``ButtonLabel``.
@@ -22,9 +19,6 @@ public protocol AccountSetupViewStyle {
     /// A small account summary that is rendered if ``AccountSetup`` is presented on an already
     /// signed in user.
     associatedtype AccountSummaryView: View
-
-    /// The associated ``AccountService`` instance.
-    var service: Service { get }
 
     /// A `ViewModifier` that is injected into views with security related operations.
     ///
@@ -38,15 +32,15 @@ public protocol AccountSetupViewStyle {
 
     /// The button label in the list of account services for the ``AccountSetup`` view.
     @ViewBuilder
-    func makeServiceButtonLabel() -> ButtonLabel
+    func makeServiceButtonLabel(_ service: any AccountService) -> ButtonLabel
 
     /// The primary view that is opened as the destination of the ``makeServiceButtonLabel()-6ihdh`` button.
     @ViewBuilder
-    func makePrimaryView() -> PrimaryView
+    func makePrimaryView(_ service: any AccountService) -> PrimaryView
 
     /// The account summary that is presented in the ``AccountSetup`` for an already signed in user.
     @ViewBuilder
-    func makeAccountSummary(details: AccountDetails) -> AccountSummaryView
+    func makeAccountSummary(_ service: any AccountService, details: AccountDetails) -> AccountSummaryView
 }
 
 
@@ -58,7 +52,7 @@ extension AccountSetupViewStyle {
 
 
     /// Default service button label using the ``AccountServiceName`` and ``AccountServiceImage`` configurations.
-    public func makeServiceButtonLabel() -> some View {
+    public func makeServiceButtonLabel(_ service: any AccountService) -> some View {
         Group {
             service.configuration.image
                 .font(.title2)
@@ -69,7 +63,7 @@ extension AccountSetupViewStyle {
     }
 
     /// Default account summary using ``AccountSummaryBox``.
-    public func makeAccountSummary(details: AccountDetails) -> some View {
+    public func makeAccountSummary(_ service: any AccountService, details: AccountDetails) -> some View {
         AccountSummaryBox(details: details)
     }
 }

--- a/Sources/SpeziAccount/AccountSetupViewStyle/EmbeddableAccountSetupViewStyle.swift
+++ b/Sources/SpeziAccount/AccountSetupViewStyle/EmbeddableAccountSetupViewStyle.swift
@@ -11,12 +11,12 @@ import SwiftUI
 
 
 /// A view style defining UI components for an associated ``EmbeddableAccountService``.
-public protocol EmbeddableAccountSetupViewStyle: AccountSetupViewStyle where Service: EmbeddableAccountService {
+public protocol EmbeddableAccountSetupViewStyle: AccountSetupViewStyle {
     /// The view that is embedded into the ``AccountSetup`` view if the associated ``EmbeddableAccountService``
     /// is the only configured embeddable account service.
     associatedtype EmbeddedView: View
 
     /// The view that is embedded into the ``AccountSetup`` view if applicable.
     @ViewBuilder
-    func makeEmbeddedAccountView() -> EmbeddedView
+    func makeEmbeddedAccountView(_ service: any EmbeddableAccountService) -> EmbeddedView
 }

--- a/Sources/SpeziAccount/AccountSetupViewStyle/IdentityProviderViewStyle.swift
+++ b/Sources/SpeziAccount/AccountSetupViewStyle/IdentityProviderViewStyle.swift
@@ -10,24 +10,24 @@ import SwiftUI
 
 
 /// A view style defining UI components for an associated ``IdentityProvider``.
-public protocol IdentityProviderViewStyle: AccountSetupViewStyle where Service: IdentityProvider, PrimaryView == Never, ButtonLabel == Never {
+public protocol IdentityProviderViewStyle: AccountSetupViewStyle where PrimaryView == Never, ButtonLabel == Never {
     /// The view rendering the sign in button.
     associatedtype Button: View
 
     /// Render the sign in button.
     @ViewBuilder
-    func makeSignInButton() -> Button
+    func makeSignInButton(_ provider: any IdentityProvider) -> Button
 }
 
 
 extension IdentityProviderViewStyle {
     /// Implementation that results in a fatal error as these methods are unavailable on identity providers.
-    public func makeServiceButtonLabel() -> Never {
+    public func makeServiceButtonLabel(_ service: any AccountService) -> Never {
         preconditionFailure("makeServiceButtonLabel() is not available on `IdentityProvider`s")
     }
 
     /// Implementation that results in a fatal error as these methods are unavailable on identity providers.
-    public func makePrimaryView() -> Never {
+    public func makePrimaryView(_ service: any AccountService) -> Never {
         preconditionFailure("makePrimaryView() is not available on `IdentityProvider`s")
     }
 }

--- a/Sources/SpeziAccount/AccountSetupViewStyle/UserIdPasswordAccountSetupViewStyle.swift
+++ b/Sources/SpeziAccount/AccountSetupViewStyle/UserIdPasswordAccountSetupViewStyle.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 /// A view style defining UI components for an associated ``UserIdPasswordAccountService``.
-public protocol UserIdPasswordAccountSetupViewStyle: EmbeddableAccountSetupViewStyle where Service: UserIdPasswordAccountService {
+public protocol UserIdPasswordAccountSetupViewStyle: EmbeddableAccountSetupViewStyle {
     /// A view that is rendered to signup a new user.
     associatedtype SignupView: View
     /// A view that is rendered to reset the user's password.
@@ -19,32 +19,38 @@ public protocol UserIdPasswordAccountSetupViewStyle: EmbeddableAccountSetupViewS
 
     /// The view that is presented to signup a new user.
     @ViewBuilder
-    func makeSignupView() -> SignupView
+    func makeSignupView(_ service: any UserIdPasswordAccountService) -> SignupView
 
     /// The view that is presented to reset a user's password.
     @ViewBuilder
-    func makePasswordResetView() -> PasswordResetView
+    func makePasswordResetView(_ service: any UserIdPasswordAccountService) -> PasswordResetView
 }
 
 
 extension UserIdPasswordAccountSetupViewStyle {
     /// Default primary view using ``UserIdPasswordPrimaryView``.
-    public func makePrimaryView() -> some View {
-        UserIdPasswordPrimaryView(using: service)
+    public func makePrimaryView(_ service: any AccountService) -> some View {
+        guard let service = service as? any UserIdPasswordAccountService else {
+            preconditionFailure("Received account service of type \(type(of: service)) when expecting one of type \((any UserIdPasswordAccountService).self)")
+        }
+        return UserIdPasswordPrimaryView(using: service)
     }
 
     /// Default embedded account view using ``UserIdPasswordEmbeddedView``.
-    public func makeEmbeddedAccountView() -> some View {
-        UserIdPasswordEmbeddedView(using: service)
+    public func makeEmbeddedAccountView(_ service: any EmbeddableAccountService) -> some View {
+        guard let service = service as? any UserIdPasswordAccountService else {
+            preconditionFailure("Received account service of type \(type(of: service)) when expecting one of type \((any UserIdPasswordAccountService).self)")
+        }
+        return UserIdPasswordEmbeddedView(using: service)
     }
 
     /// Default signup view using ``SignupForm``.
-    public func makeSignupView() -> some View {
+    public func makeSignupView(_ service: any UserIdPasswordAccountService) -> some View {
         SignupForm(using: service)
     }
 
     /// Default password reset view using ``UserIdPasswordResetView`` and ``SuccessfulPasswordResetView``.
-    public func makePasswordResetView() -> some View {
+    public func makePasswordResetView(_ service: any UserIdPasswordAccountService) -> some View {
         UserIdPasswordResetView(using: service) {
             SuccessfulPasswordResetView()
         }

--- a/Sources/SpeziAccount/AccountValue/AccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey.swift
@@ -54,6 +54,11 @@ public protocol AccountKey: KnowledgeSource<AccountAnchor> where Value: Sendable
     /// The localized name describing a value of this `AccountKey`.
     static var name: LocalizedStringResource { get }
 
+    /// A string-based identifier that is meant to be stable. Used by storage modules.
+    ///
+    /// By default this maps to the type name.
+    static var identifier: String { get }
+
 
     /// The category of the account key.
     ///
@@ -77,9 +82,14 @@ public protocol AccountKey: KnowledgeSource<AccountAnchor> where Value: Sendable
 
 
 extension AccountKey {
-    /// A unique identifier for an account key.
+    /// A unique identifier for an account key. Bound to the process lifetime.
     public static var id: ObjectIdentifier {
         ObjectIdentifier(Self.self)
+    }
+
+    /// Default implementation falling back to the Swift type name.
+    public static var identifier: String {
+        "\(Self.self)"
     }
 
     static var isRequired: Bool {

--- a/Sources/SpeziAccount/Mock/MockSignInWithAppleProvider.swift
+++ b/Sources/SpeziAccount/Mock/MockSignInWithAppleProvider.swift
@@ -27,15 +27,9 @@ private struct MockButton: View {
 
 /// Mock ``IdentityProviderViewStyle`` view style for the ``MockSignInWithAppleProvider``.
 public struct MockSignInWithAppleProviderStyle: IdentityProviderViewStyle {
-    public let service: MockSignInWithAppleProvider
+    public typealias Service = MockSignInWithAppleProvider
 
-    
-    fileprivate init(service: MockSignInWithAppleProvider) {
-        self.service = service
-    }
-
-
-    public func makeSignInButton() -> some View {
+    public func makeSignInButton(_ provider: any IdentityProvider) -> some View {
         MockButton()
     }
 }
@@ -49,9 +43,7 @@ public struct MockSignInWithAppleProviderStyle: IdentityProviderViewStyle {
 public actor MockSignInWithAppleProvider: IdentityProvider {
     public let configuration = AccountServiceConfiguration(name: "Mock SignIn with Apple", supportedKeys: .arbitrary)
 
-    public nonisolated var viewStyle: MockSignInWithAppleProviderStyle {
-        MockSignInWithAppleProviderStyle(service: self)
-    }
+    public let viewStyle = MockSignInWithAppleProviderStyle()
 
 
     public init() {}

--- a/Sources/SpeziAccount/Mock/MockSignInWithAppleProvider.swift
+++ b/Sources/SpeziAccount/Mock/MockSignInWithAppleProvider.swift
@@ -27,8 +27,6 @@ private struct MockButton: View {
 
 /// Mock ``IdentityProviderViewStyle`` view style for the ``MockSignInWithAppleProvider``.
 public struct MockSignInWithAppleProviderStyle: IdentityProviderViewStyle {
-    public typealias Service = MockSignInWithAppleProvider
-
     public func makeSignInButton(_ provider: any IdentityProvider) -> some View {
         MockButton()
     }

--- a/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
+++ b/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// The view style for the `MockSimpleAccountService` rendering `"Hello World"` text.
 struct MockSimpleAccountSetupViewStyle: AccountSetupViewStyle {
-    public typealias Service = MockSimpleAccountService
+    typealias Service = MockSimpleAccountService
 
 
     func makePrimaryView(_ service: any AccountService) -> some View {
@@ -27,7 +27,7 @@ actor MockSimpleAccountService: AccountService {
     let configuration = AccountServiceConfiguration(name: "Mock Simple AccountService", supportedKeys: .arbitrary)
 
 
-    public let viewStyle = MockSimpleAccountSetupViewStyle()
+    let viewStyle = MockSimpleAccountSetupViewStyle()
 
 
     init() {}

--- a/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
+++ b/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
@@ -11,15 +11,10 @@ import SwiftUI
 
 /// The view style for the `MockSimpleAccountService` rendering `"Hello World"` text.
 struct MockSimpleAccountSetupViewStyle: AccountSetupViewStyle {
-    var service: MockSimpleAccountService
+    public typealias Service = MockSimpleAccountService
 
 
-    init(using service: MockSimpleAccountService) {
-        self.service = service
-    }
-
-
-    func makePrimaryView() -> some View {
+    func makePrimaryView(_ service: any AccountService) -> some View {
         Text(verbatim: "Hello World")
     }
 }
@@ -32,9 +27,7 @@ actor MockSimpleAccountService: AccountService {
     let configuration = AccountServiceConfiguration(name: "Mock Simple AccountService", supportedKeys: .arbitrary)
 
 
-    nonisolated var viewStyle: some AccountSetupViewStyle {
-        MockSimpleAccountSetupViewStyle(using: self)
-    }
+    public let viewStyle = MockSimpleAccountSetupViewStyle()
 
 
     init() {}

--- a/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
+++ b/Sources/SpeziAccount/Mock/MockSimpleAccountService.swift
@@ -11,9 +11,6 @@ import SwiftUI
 
 /// The view style for the `MockSimpleAccountService` rendering `"Hello World"` text.
 struct MockSimpleAccountSetupViewStyle: AccountSetupViewStyle {
-    typealias Service = MockSimpleAccountService
-
-
     func makePrimaryView(_ service: any AccountService) -> some View {
         Text(verbatim: "Hello World")
     }

--- a/Sources/SpeziAccount/SpeziAccount.docc/Setup Guides/Using the Account Object.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Setup Guides/Using the Account Object.md
@@ -17,8 +17,8 @@ Use the global `Account` object to access the current account state.
 ## Overview
 
 You can use the ``Account`` object
-that is injected into your App's view hierarchy as an environment object to access ``SpeziAccount`` state.
-Particularly useful are the published properties ``Account/signedIn`` and ``Account/details`` to access the current account
+that is injected into your App's view hierarchy as an environment object to access `SpeziAccount` state.
+Particularly useful are the properties ``Account/signedIn`` and ``Account/details`` to access the current account
 state.
 
 Below is a short code example to access the global ``Account`` instance.
@@ -34,7 +34,7 @@ struct MyView: View {
 
 ## Topics
 
-### Account and Account Details
+### Account Details
 
 - ``Account``
 - ``Account/signedIn``
@@ -45,6 +45,7 @@ struct MyView: View {
 
 Below is a list of built-in account details. Other frameworks might extend this list.
 
+- ``AccountDetails/accountId``
 - ``AccountDetails/userId``
 - ``AccountDetails/email``
 - ``AccountDetails/name``

--- a/Sources/SpeziAccount/Views/AccountSetup/AccountServiceButtonList.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/AccountServiceButtonList.swift
@@ -20,9 +20,9 @@ struct AccountServiceButtonList: View {
             let style = service.viewStyle
 
             NavigationLink {
-                AnyView(style.makePrimaryView())
+                AnyView(style.makePrimaryView(service))
             } label: {
-                style.makeAnyAccountServiceButtonLabel()
+                style.makeAnyAccountServiceButtonLabel(service)
             }
         }
     }
@@ -34,10 +34,10 @@ struct AccountServiceButtonList: View {
 
 
 extension AccountSetupViewStyle {
-    fileprivate func makeAnyAccountServiceButtonLabel() -> AnyView {
+    fileprivate func makeAnyAccountServiceButtonLabel(_ service: any AccountService) -> AnyView {
         // as the `AccountSetup` only has a type-erased view on the `AccountSetupViewStyle`
         // we can't, because of the default implementation, create the AnyView inline.
-        AnyView(self.makeServiceButtonLabel())
+        AnyView(self.makeServiceButtonLabel(service))
     }
 }
 

--- a/Sources/SpeziAccount/Views/AccountSetup/AccountServicesSection.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/AccountServicesSection.swift
@@ -31,7 +31,7 @@ struct AccountServicesSection: View {
     var body: some View {
         if let embeddableService = embeddableAccountService {
             let embeddableViewStyle = embeddableService.viewStyle
-            AnyView(embeddableViewStyle.makeEmbeddedAccountView())
+            AnyView(embeddableViewStyle.makeEmbeddedAccountView(embeddableService))
 
             if !nonEmbeddableAccountServices.isEmpty {
                 ServicesDivider()

--- a/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
@@ -24,7 +24,7 @@ struct ExistingAccountView<Continue: View>: View {
     var body: some View {
         VStack {
             VStack {
-                AnyView(service.viewStyle.makeAnyAccountSummary(details: accountDetails))
+                service.viewStyle.makeAnyAccountSummary(service, details: accountDetails)
 
                 AsyncButton(.init("UP_LOGOUT", bundle: .atURL(from: .module)), role: .destructive, state: $viewState) {
                     try await service.logout()
@@ -65,8 +65,8 @@ struct ExistingAccountView<Continue: View>: View {
 
 
 extension AccountSetupViewStyle {
-    fileprivate func makeAnyAccountSummary(details: AccountDetails) -> AnyView {
-        AnyView(self.makeAccountSummary(details: details))
+    fileprivate func makeAnyAccountSummary(_ service: any AccountService, details: AccountDetails) -> AnyView {
+        AnyView(self.makeAccountSummary(service, details: details))
     }
 }
 

--- a/Sources/SpeziAccount/Views/AccountSetup/IdentityProviderSection.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/IdentityProviderSection.swift
@@ -15,7 +15,7 @@ struct IdentityProviderSection: View {
     var body: some View {
         VStack {
             ForEach(providers.indices, id: \.self) { index in
-                providers[index].viewStyle.makeAnySignInButton()
+                providers[index].viewStyle.makeAnySignInButton(providers[index])
             }
         }
     }
@@ -27,8 +27,8 @@ struct IdentityProviderSection: View {
 
 
 extension IdentityProviderViewStyle {
-    func makeAnySignInButton() -> AnyView {
-        AnyView(self.makeSignInButton())
+    func makeAnySignInButton(_ provider: any IdentityProvider) -> AnyView {
+        AnyView(self.makeSignInButton(provider))
     }
 }
 

--- a/Sources/SpeziAccount/Views/SignupForm.swift
+++ b/Sources/SpeziAccount/Views/SignupForm.swift
@@ -43,8 +43,8 @@ struct DefaultSignupFormHeader: View {
 /// split into `Section`s according the their ``AccountKeyCategory`` (see ``AccountKey/category``).
 ///
 /// - Note: This view is built with the assumption to be placed inside a `NavigationStack` within a Sheet modifier.
-public struct SignupForm<Service: AccountService, Header: View>: View {
-    private let service: Service
+public struct SignupForm<Header: View>: View {
+    private let service: any AccountService
     private let header: Header
 
     @Environment(Account.self) private var account
@@ -132,12 +132,12 @@ public struct SignupForm<Service: AccountService, Header: View>: View {
     }
 
 
-    init(using service: Service) where Header == DefaultSignupFormHeader {
+    init(using service: any AccountService) where Header == DefaultSignupFormHeader {
         self.service = service
         self.header = DefaultSignupFormHeader()
     }
 
-    init(service: Service, @ViewBuilder header: () -> Header) {
+    init(service: any AccountService, @ViewBuilder header: () -> Header) {
         self.service = service
         self.header = header()
     }

--- a/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordEmbeddedView.swift
@@ -22,8 +22,8 @@ private enum LoginFocusState {
 /// Every ``EmbeddableAccountService`` might provide a view that is directly integrated into the ``AccountSetup``
 /// view for more easy navigation. This view implements such a view for ``UserIdPasswordAccountService``-based
 /// account service implementations.
-public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>: View {
-    private let service: Service
+public struct UserIdPasswordEmbeddedView: View {
+    private let service: any UserIdPasswordAccountService
     private var userIdConfiguration: UserIdConfiguration {
         service.configuration.userIdConfiguration
     }
@@ -74,12 +74,12 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
             .receiveValidation(in: $validation)
             .sheet(isPresented: $presentingSignupSheet) {
                 NavigationStack {
-                    service.viewStyle.makeSignupView()
+                    service.viewStyle.makeAnySignupForm(service)
                 }
             }
             .sheet(isPresented: $presentingPasswordForgetSheet) {
                 NavigationStack {
-                    service.viewStyle.makePasswordResetView()
+                    service.viewStyle.makeAnyPasswordResetView(service)
                         .navigationBarTitleDisplayMode(.inline)
                 }
             }
@@ -123,7 +123,7 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
 
     /// Create a new embedded view.
     /// - Parameter service: The ``UserIdPasswordAccountService`` instance.
-    public init(using service: Service) {
+    public init(using service: any UserIdPasswordAccountService) {
         self.service = service
     }
 
@@ -137,6 +137,17 @@ public struct UserIdPasswordEmbeddedView<Service: UserIdPasswordAccountService>:
         focusedField = nil
 
         try await service.login(userId: userId, password: password)
+    }
+}
+
+
+extension UserIdPasswordAccountSetupViewStyle {
+    fileprivate func makeAnySignupForm(_ service: any UserIdPasswordAccountService) -> AnyView {
+        AnyView(makeSignupView(service))
+    }
+
+    fileprivate func makeAnyPasswordResetView(_ service: any UserIdPasswordAccountService) -> AnyView {
+        AnyView(makePasswordResetView(service))
     }
 }
 

--- a/Sources/SpeziAccount/Views/UserIdPasswordPrimaryView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordPrimaryView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 
 
 /// A primary view implementation for a ``UserIdPasswordAccountService``.
-public struct UserIdPasswordPrimaryView<Service: UserIdPasswordAccountService>: View {
-    private let service: Service
+public struct UserIdPasswordPrimaryView: View {
+    private let service: any UserIdPasswordAccountService
 
 
     public var body: some View {
@@ -40,7 +40,7 @@ public struct UserIdPasswordPrimaryView<Service: UserIdPasswordAccountService>: 
     }
 
 
-    init(using service: Service) {
+    init(using service: any UserIdPasswordAccountService) {
         self.service = service
     }
 }

--- a/Sources/SpeziAccount/Views/UserIdPasswordResetView.swift
+++ b/Sources/SpeziAccount/Views/UserIdPasswordResetView.swift
@@ -12,8 +12,8 @@ import SwiftUI
 
 
 /// A password reset view implementation for a ``UserIdPasswordAccountService``.
-public struct UserIdPasswordResetView<Service: UserIdPasswordAccountService, SuccessView: View>: View {
-    private let service: Service
+public struct UserIdPasswordResetView<SuccessView: View>: View {
+    private let service: any UserIdPasswordAccountService
     private let successView: SuccessView
 
     private var userIdConfiguration: UserIdConfiguration {
@@ -87,7 +87,11 @@ public struct UserIdPasswordResetView<Service: UserIdPasswordAccountService, Suc
             .environment(\.defaultErrorDescription, .init("UAP_RESET_PASSWORD_FAILED_DEFAULT_ERROR", bundle: .atURL(from: .module)))
     }
 
-    fileprivate init(using service: Service, requestSubmitted: Bool, @ViewBuilder success successViewBuilder: () -> SuccessView) {
+    fileprivate init(
+        using service: any UserIdPasswordAccountService,
+        requestSubmitted: Bool,
+        @ViewBuilder success successViewBuilder: () -> SuccessView
+    ) {
         self.service = service
         self.successView = successViewBuilder()
         self._requestSubmitted = State(wrappedValue: requestSubmitted)
@@ -98,7 +102,7 @@ public struct UserIdPasswordResetView<Service: UserIdPasswordAccountService, Suc
     /// - Parameters:
     ///   - service: The ``UserIdPasswordAccountService`` instance.
     ///   - successViewBuilder: A view to display on successful password reset.
-    public init(using service: Service, @ViewBuilder success successViewBuilder: @escaping () -> SuccessView) {
+    public init(using service: any UserIdPasswordAccountService, @ViewBuilder success successViewBuilder: @escaping () -> SuccessView) {
         self.init(using: service, requestSubmitted: false, success: successViewBuilder)
     }
 

--- a/Tests/UITests/TestApp/AccountTests/TestAccountService.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAccountService.swift
@@ -11,9 +11,6 @@ import SwiftUI
 
 
 struct TestViewStyle: UserIdPasswordAccountSetupViewStyle {
-    let service: TestAccountService
-
-
     var securityRelatedViewModifier: any ViewModifier {
         TestAlertModifier()
     }
@@ -31,9 +28,7 @@ actor TestAccountService: UserIdPasswordAccountService {
     @AccountReference var account: Account
     var registeredUser: UserStorage // simulates the backend
 
-    nonisolated var viewStyle: TestViewStyle {
-        TestViewStyle(service: self)
-    }
+    let viewStyle = TestViewStyle()
 
 
     init(_ model: TestAlertModel, _ type: UserIdType, defaultAccount: Bool = false, noName: Bool = false) {

--- a/Tests/UITests/TestApp/AccountTests/TestStandard.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestStandard.swift
@@ -18,6 +18,7 @@ actor TestStandard: AccountStorageStandard, AccountNotifyStandard, EnvironmentAc
     var records: [AdditionalRecordId: PartialAccountDetails.Builder] = [:]
 
     func create(_ identifier: AdditionalRecordId, _ details: SignupDetails) async throws {
+        print("Received created!")
         records[identifier] = PartialAccountDetails.Builder(from: details)
     }
 

--- a/Tests/UITests/TestApp/AccountTests/TestStandard.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestStandard.swift
@@ -18,7 +18,6 @@ actor TestStandard: AccountStorageStandard, AccountNotifyStandard, EnvironmentAc
     var records: [AdditionalRecordId: PartialAccountDetails.Builder] = [:]
 
     func create(_ identifier: AdditionalRecordId, _ details: SignupDetails) async throws {
-        print("Received created!")
         records[identifier] = PartialAccountDetails.Builder(from: details)
     }
 

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -250,6 +250,35 @@ final class AccountSetupTests: XCTestCase {
         overview.verifyExistence(text: "Date of Birth")
     }
 
+    func testFullSignupWithAdditionalStorage() throws {
+        let app = TestApp.launch(config: "allRequiredWithBio")
+        let signupView = app
+            .openAccountSetup()
+            .openSignup(sleep: 3)
+
+        try signupView.fillForm(
+            email: "lelandstanford2@stanford.edu",
+            password: Defaults.password,
+            name: .init("Leland Stanford"),
+            genderIdentity: "Male",
+            supplyDateOfBirth: true,
+            biography: "Hello Stanford"
+        )
+
+        signupView.signup(sleep: 3)
+
+        // Now verify what we entered
+        let overview = app.openAccountOverview(timeout: 6.0)
+
+        // verify all the details
+        overview.verifyExistence(text: "LS")
+        overview.verifyExistence(text: "Leland Stanford")
+        overview.verifyExistence(text: "lelandstanford2@stanford.edu")
+        overview.verifyExistence(text: "Gender Identity, Male")
+        overview.verifyExistence(text: "Date of Birth")
+        overview.verifyExistence(text: "Biography, Hello Stanford")
+    }
+
     func testRequirementLevelsSignup() throws {
         let app = TestApp.launch(serviceType: "mail")
         let signupView = app

--- a/Tests/UITests/TestAppUITests/Utils/SignupView.swift
+++ b/Tests/UITests/TestAppUITests/Utils/SignupView.swift
@@ -25,7 +25,8 @@ struct SignupView: AccountValueView {
         password: String,
         name: PersonNameComponents? = nil,
         genderIdentity: String? = nil,
-        supplyDateOfBirth: Bool = false
+        supplyDateOfBirth: Bool = false,
+        biography: String? = nil
     ) throws {
         // we access through collectionViews as there is another E-Mail Address and Password field behind the signup sheet
         XCTAssertTrue(app.collectionViews.textFields["E-Mail Address"].waitForExistence(timeout: 1.0))
@@ -43,12 +44,18 @@ struct SignupView: AccountValueView {
             }
         }
 
+        usleep(500_000) // wait for the keyboard to fully disappear
+        
         if let genderIdentity {
             self.updateGenderIdentity(from: "Choose not to answer", to: genderIdentity)
         }
 
         if supplyDateOfBirth {
             self.changeDatePreviousMonthFirstDay()
+        }
+
+        if let biography {
+            try self.enter(field: "Biography", text: biography)
         }
     }
 

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -64,11 +64,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--configuration-type"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "allRequired"
-            isEnabled = "NO">
+            argument = "allRequiredWithBio"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--default-credentials"


### PR DESCRIPTION
# Restore functionality of the storage standard

## :recycle: Current situation & Problem
This PR restores the functionality of the `AccountStorageStandard`. There was an issue with SpeziAccount where account creation wasn't correctly picked up by the configured storage standard.
We had to reengineer some parts of the SpeziAccount infrastructure to ensure the Storage Standard is called at all times.


## :gear: Release Notes 
* Fix storage standard


## :books: Documentation
--

## :white_check_mark: Testing
New tests cases were added to verify the functionality and protect us against regressions.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
