### PR TITLE
Do not use .newPassword content type within simulator

### DIFF
--- a/Sources/SpeziAccount/AccountValue/Keys/PasswordKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/PasswordKey.swift
@@ -77,7 +77,12 @@ extension PasswordKey {
             switch accountViewType {
             case .signup, .none:
                 VerifiableTextField(fieldType.localizedStringResource, text: $password, type: .secure)
+                    #if targetEnvironment(simulator)
+                    // we do not use `.newPassword` within simulator builds to not interfer with UI tests
+                    .textContentType(.password)
+                    #else
                     .textContentType(.newPassword)
+                    #endif
                     .disableFieldAssistants()
             case .overview: // display description labels in the PasswordChangeSheet (as we have two password fields)
                 DescriptionGridRow {
@@ -86,7 +91,12 @@ extension PasswordKey {
                     SecureField(text: $password) {
                         Text(fieldType.localizedPrompt)
                     }
+                        #if targetEnvironment(simulator)
+                        // we do not use `.newPassword` within simulator builds to not interfer with UI tests
+                        .textContentType(.password)
+                        #else
                         .textContentType(.newPassword)
+                        #endif
                         .disableFieldAssistants()
                 }
 

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -15,8 +15,6 @@ final class AccountOverviewTests: XCTestCase {
         try super.setUpWithError()
 
         continueAfterFailure = false
-
-        try disablePasswordAutofill()
     }
 
     func testRequirementLevelsOverview() throws {

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -15,8 +15,6 @@ final class AccountSetupTests: XCTestCase {
         try super.setUpWithError()
 
         continueAfterFailure = false
-
-        try disablePasswordAutofill()
     }
 
     func testEmbeddedViewValidation() throws {


### PR DESCRIPTION
# Do not use .newPassword content type within simulator

## :recycle: Current situation & Problem
Previously, we would disable password auto-fill within the simulator to avoid the simulator proposing a pre-filled password that would otherwise interfere with our UI tests. This approach broke with iOS 17.2 simulator and our workaround seems to not always work.
Instead, this PR just avoids using the `.newPassword` content type when running within the simulator.


## :gear: Release Notes 
* Avoid using `.newPassword` text content type when running within the simulator.


## :books: Documentation
Inline docs were added.


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
