### PR TITLE
Follow Up Collected Information

### DIFF
--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -115,7 +115,8 @@ public struct AccountSetup<Header: View, Continue: View>: View {
         }
             .onChange(of: account.signedIn) {
                 if let details = account.details, case .setupShown = setupState {
-                    let missingKeys = account.configuration.missingRequiredKeys(for: details, includeCollected: details.isNewUser)
+                    // set includeCollected to true to collect the same information through self sign-up and administered signup
+                    let missingKeys = account.configuration.missingRequiredKeys(for: details, includeCollected: true)
 
                     if missingKeys.isEmpty {
                         setupState = .loadingExistingAccount


### PR DESCRIPTION
# Follow Up Collected Information

## :recycle: Current situation & Problem
In the default configuration, the date of birth and the gender identity are `.collected`, but not `.required`. When the user uses the self signup method, they are presented with items from both categories. However, in some use cases, self-signup might not be the preferable way how users log into an application. In this case a provider can create an account for them (e.g. through Firebase). When the user logs in for the first time the `details.isNewUser` is no longer `true` and only the `.required` categories are displayed. In case an application allows for both self-signup and provider sign-up this leads to a difference in collected information about the user which is undesirable.

## :gear: Release Notes 
- The only change required to change this behavior is modify `.onChange` in the `AccountSetup.swift` file to always collect the `.collected` and `.required` information. 


## :books: Documentation
By setting the `includeCollected` argument of the `missingRequiredKeys` always to `true` results that the user is always presented with the full follow up sheet, not just the truncated version. Note that by doing this, fields of the `.collected` category still are not mandatory.


## :white_check_mark: Testing
The behavior was intensively tested with the TBI application developed as part of Stanford CS342 and no issues were found.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
