### PR TITLE
Update Adding new Account Values

### DIFF
--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
@@ -99,20 +99,24 @@ conformance to your `Value` type.
 
 However, if your `Value` is not `String`-based, you need to implement your own DataDisplayView. Below is a short code example that demonstrates how to implement a DataDisplayView for which the `Value` is `Int`-based for a HeightValue Key.
 ```swift
-public struct DataDisplay: DataDisplayView {
-    public typealias Key = HeightKey
-    private let height: Int
-    public init(_ value: Int) {
-        self.height = value
-    }
-    public var body: some View {
-        HStack {
-            Text(HeightKey.name)
-            Spacer()
-            Text("\(height) cm")
-                .foregroundColor(.secondary)
+extension HeightKey {
+    public struct DataDisplay: DataDisplayView {
+        public typealias Key = HeightKey
+        private let height: Int
+        
+        public var body: some View {
+            HStack {
+                Text(HeightKey.name)
+                Spacer()
+                Text("\(height) cm")
+                    .foregroundColor(.secondary)
+            }
+                    .accessibilityElement(children: .combine)
         }
-        .accessibilityElement(children: .combine)
+
+        public init(_ value: Int) {
+            self.height = value
+        }
     }
 }
 ```

--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
@@ -97,6 +97,26 @@ Therefore, you typically do not need to provide a custom view implementation,
 or you might consider adding `CustomLocalizedStringResourceConvertible` protocol
 conformance to your `Value` type.
 
+However, if your `Value` is not `String`-based, you need to implement your own DataDisplayView. Below is a short code example that demonstrates how to implement a DataDisplayView for which the `Value` is `Int`-based for a HeightValue Key.
+```swift
+public struct DataDisplay: DataDisplayView {
+    public typealias Key = HeightKey
+    private let height: Int
+    public init(_ value: Int) {
+        self.height = value
+    }
+    public var body: some View {
+        HStack {
+            Text(HeightKey.name)
+            Spacer()
+            Text("\(height) cm")
+                .foregroundColor(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+```
+
 > Note: For more information on how to implement your custom data display view, refer to the ``DataDisplayView`` protocol.
 
 #### Data Entry View

--- a/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/Account Values/Adding new Account Values.md
@@ -111,7 +111,7 @@ extension HeightKey {
                 Text("\(height) cm")
                     .foregroundColor(.secondary)
             }
-                    .accessibilityElement(children: .combine)
+                .accessibilityElement(children: .combine)
         }
 
         public init(_ value: Int) {


### PR DESCRIPTION
# Updating Adding new Account Values Page

## :recycle: Current situation & Problem
Prior, there were no code examples for creating a custom DataDisplayView for non-String based values. 


## :gear: Release Notes 
- Highlighted example of creating custom DataDisplayView using an Int-based Value. 
<img width="734" alt="Screenshot 2024-03-04 at 10 58 10 am" src="https://github.com/StanfordSpezi/SpeziAccount/assets/137839789/3a06a471-2341-457f-af72-cc936db860c6">


## :books: Documentation
- added sentence highlighting the difference between the default String-based DataDisplayView and a custom DataDisplayView of different value type
- wrote one-sentence description of the example of a HeightValue Key
- inserted code example


## :white_check_mark: Testing



## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
