### PR TITLE
Inject security related modifier in single edit view

### DIFF
--- a/Sources/SpeziAccount/AccountValue/AccountKeyCategory.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyCategory.swift
@@ -22,7 +22,7 @@ import Foundation
 /// - ``contactDetails``
 /// - ``personalDetails``
 /// - ``other``
-public struct AccountKeyCategory {
+public struct AccountKeyCategory: Sendable {
     /// A category to group account credentials.
     public static let credentials = AccountKeyCategory(title: LocalizedStringResource("UP_CREDENTIALS", bundle: .atURL(from: .module)))
 

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -53,7 +53,6 @@ struct NameOverview: View {
                 }
             }
         }
-            .anyViewModifier(service.viewStyle.securityRelatedViewModifier)
             .navigationTitle(model.accountIdentifierLabel(configuration: account.configuration, userIdType: accountDetails.userIdType))
             .navigationBarTitleDisplayMode(.inline)
             .injectEnvironmentObjects(service: accountDetails.accountService, model: model)

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -30,6 +30,7 @@ struct NameOverview: View {
                 Section {
                     NavigationLink {
                         wrapper.accountKey.singleEditView(model: model, details: accountDetails)
+                            .anyViewModifier(service.viewStyle.securityRelatedViewModifier)
                     } label: {
                         if let view = wrapper.accountKey.dataDisplayViewWithCurrentStoredValue(from: accountDetails) {
                             view

--- a/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
@@ -46,10 +46,14 @@ public struct DefaultAccountSetupHeader: View {
 struct DefaultAccountSetupHeader_Previews: PreviewProvider {
     static var previews: some View {
         DefaultAccountSetupHeader()
-            .environment(Account())
+            .previewWith {
+                AccountConfiguration()
+            }
 
         DefaultAccountSetupHeader()
-            .environment(Account(building: .init().set(\.userId, value: "myUser"), active: MockUserIdPasswordAccountService()))
+            .previewWith {
+                AccountConfiguration(building: .init().set(\.userId, value: "myUser"), active: MockUserIdPasswordAccountService())
+            }
     }
 }
 #endif

--- a/Tests/UITests/TestApp/AccountTests/TestAlertModifier.swift
+++ b/Tests/UITests/TestApp/AccountTests/TestAlertModifier.swift
@@ -19,9 +19,11 @@ final class TestAlertModel: @unchecked Sendable {
 struct TestAlertModifier: ViewModifier {
     @Environment(TestAlertModel.self) var model
 
+    @State private var isActive = false
+
     var isPresented: Binding<Bool> {
         Binding {
-            model.presentingAlert
+            model.presentingAlert && isActive
         } set: { newValue in
             model.presentingAlert = newValue
         }
@@ -30,6 +32,12 @@ struct TestAlertModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .onAppear {
+                isActive = true
+            }
+            .onDisappear {
+                isActive = false
+            }
             .alert("Security Alert", isPresented: isPresented, presenting: model.continuation) { continuation in
                 Button("Dismiss") {
                     continuation.resume()


### PR DESCRIPTION
# Inject security related modifier in single edit view

## :recycle: Current situation & Problem
This PR addresses an issue where the `securityRelatedViewModifier` of an account service was not injected into the single row edit view.

## :gear: Release Notes 
* Inject security related modifier in single edit view


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
