### PR TITLE
Fix appearance of AccountSetup Header when only using identity provider

### DIFF
--- a/Sources/SpeziAccount/Account.swift
+++ b/Sources/SpeziAccount/Account.swift
@@ -93,6 +93,7 @@ public final class Account: @unchecked Sendable {
     ///     ``AccountSetupViewStyle`` implementations (see ``IdentityProviderViewStyle``).
     public let registeredAccountServices: [any AccountService]
 
+
     /// Initialize a new `Account` object by providing all properties individually.
     /// - Parameters:
     ///   - services: A collection of ``AccountService`` that are used to handle account-related functionality.

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -78,7 +78,7 @@ public struct AccountSetup<Header: View, Continue: View>: View {
         GeometryReader { proxy in
             ScrollView(.vertical) {
                 VStack {
-                    if !services.isEmpty {
+                    if !services.isEmpty || !identityProviders.isEmpty {
                         header
                             .environment(\._accountSetupState, setupState)
                     }
@@ -239,6 +239,9 @@ struct AccountView_Previews: PreviewProvider {
             AccountSetup()
                 .environment(Account(services: accountServicePermutations[index] + [MockSignInWithAppleProvider()]))
         }
+
+        AccountSetup()
+            .environment(Account(services: [MockSignInWithAppleProvider()]))
 
         AccountSetup()
             .previewWith {


### PR DESCRIPTION
# Fix appearance of AccountSetup Header when only using identity provider

## :recycle: Current situation & Problem
There was a faulty check resulting in the AccountSetup Header not being displayed when only using Identity Provider.

## :gear: Release Notes 
* Fixed an issue where the AccountSetup Header wouldn't be displayed with only using identity provider.


## :books: Documentation
--


## :white_check_mark: Testing
We added another permutation in the Preview section.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
