### PR TITLE
Fix AccountSetup closure not getting called when anonymous details are associated

### DIFF
--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -122,8 +122,9 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                     .frame(maxWidth: .infinity)
             }
         }
-            .onChange(of: account.signedIn) {
+            .onChange(of: [account.signedIn, account.details?.isAnonymous]) {
                 guard let details = account.details,
+                      !details.isAnonymous,
                       case .setupShown = setupState else {
                     return
                 }

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -181,8 +181,8 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertTrue(app.collectionViews.buttons["Signup"].waitForExistence(timeout: 1.0))
         app.collectionViews.buttons["Signup"].tap()
 
-        XCTAssertTrue(app.buttons["Finish"].waitForExistence(timeout: 2.0))
-        app.buttons["Finish"].tap()
+        // important: if the sheet isn't dismissed it may indicate that the completion closure of the AccountSetup view
+        // is no longer getting called. This is implicitly tested here.
 
         XCTAssertTrue(app.staticTexts[Defaults.email].waitForExistence(timeout: 2.0))
         XCTAssertTrue(app.staticTexts["Account Id, Stable"].exists)


### PR DESCRIPTION
# Fix AccountSetup closure not getting called when anonymous details are associated

## :recycle: Current situation & Problem
The AccountSetup inconsistently treated anonymous account details (still showing the setup views but not reacting to changes when going from anonymous to non-anonymous). This is fixed by this PR.

## :gear: Release Notes 
* Fixed account setup closure not being called if anonymous details were previously associated.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
