### PR TITLE
Handle CancellationError from account services

### DIFF
--- a/Sources/SpeziAccount/AccountStorageProvider.swift
+++ b/Sources/SpeziAccount/AccountStorageProvider.swift
@@ -40,8 +40,7 @@ public protocol AccountStorageProvider: Module {
     ///   - keys: The keys to load.
     /// - Returns: The externally ``AccountDetails`` if they could be loaded instantly (e.g., local cache). Otherwise, if retrieval requires an external network connection,
     ///     return `nil` and supply the account details by calling ``ExternalAccountStorage/notifyAboutUpdatedDetails(for:_:)`` once they arrive.
-    /// - Throws: A `LocalizedError`.
-    func load(_ accountId: String, _ keys: [any AccountKey.Type]) async throws -> AccountDetails?
+    func load(_ accountId: String, _ keys: [any AccountKey.Type]) async -> AccountDetails?
 
     /// Store associated account data.
     ///

--- a/Sources/SpeziAccount/ExternalAccountStorage.swift
+++ b/Sources/SpeziAccount/ExternalAccountStorage.swift
@@ -119,7 +119,7 @@ public final class ExternalAccountStorage {
     /// - Returns: The account details retrieved from the external storage. In the case that the details are not yet loaded, the ``AccountDetails/isIncomplete`` flag is
     ///     set and shall be merged into the details the account service aims to supply. Make sure to not persistently store these account details containing the ``AccountDetails/isIncomplete``
     ///     flag set to true.
-    public func retrieveExternalStorage(for accountId: String, _ keys: [any AccountKey.Type]) async throws -> AccountDetails {
+    public func retrieveExternalStorage(for accountId: String, _ keys: [any AccountKey.Type]) async -> AccountDetails {
         guard !keys.isEmpty else {
             return AccountDetails()
         }
@@ -128,7 +128,7 @@ public final class ExternalAccountStorage {
             preconditionFailure("An External AccountStorageProvider was assumed to be present. However no provider was configured.")
         }
 
-        guard let details = try await storageProvider.load(accountId, keys) else {
+        guard let details = await storageProvider.load(accountId, keys) else {
             // the storage provider currently doesn't have a local copy, they will notify us with updated details later on
             var details = AccountDetails()
             details.isIncomplete = true
@@ -144,8 +144,8 @@ public final class ExternalAccountStorage {
     ///   - accountId: The account id for which account details should be retrieved from the external storage.
     ///   - keys: The list of keys that are known to be stored externally.
     @_disfavoredOverload
-    public func retrieveExternalStorage<Keys: AcceptingAccountKeyVisitor>(for accountId: String, _ keys: Keys) async throws -> AccountDetails {
-        try await retrieveExternalStorage(for: accountId, keys._keys)
+    public func retrieveExternalStorage<Keys: AcceptingAccountKeyVisitor>(for accountId: String, _ keys: Keys) async -> AccountDetails {
+        await retrieveExternalStorage(for: accountId, keys._keys)
     }
 
 

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -19,13 +19,10 @@ private struct MockUserIdPasswordEmbeddedView: View {
 
     var body: some View {
         AccountSetupProviderView { credential in
-            let service = service
             try await service.login(userId: credential.userId, password: credential.password)
         } signup: { signupDetails in
-            let service = service
             try await service.signUp(with: signupDetails)
         } resetPassword: { userId in
-            let service = service
             try await service.resetPassword(userId: userId)
         }
     }

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -114,7 +114,15 @@ struct PasswordChangeSheet: View {
 
         account.logger.debug("Saving updated password to AccountService!")
 
-        try await model.updateAccountDetails(details: accountDetails, using: account)
+        do {
+            try await model.updateAccountDetails(details: accountDetails, using: account)
+        } catch {
+            if error is CancellationError {
+                return
+            }
+            throw error
+        }
+        
         dismiss()
     }
 

--- a/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
@@ -77,7 +77,14 @@ struct SingleEditView<Key: AccountKey>: View {
 
         account.logger.debug("Saving updated \(Key.self) value!")
 
-        try await model.updateAccountDetails(details: accountDetails, using: account)
+        do {
+            try await model.updateAccountDetails(details: accountDetails, using: account)
+        } catch {
+            if error is CancellationError {
+                return
+            }
+            throw error
+        }
         dismiss()
     }
 }

--- a/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
@@ -32,8 +32,7 @@ struct ExistingAccountView<Continue: View>: View {
                     Spacer()
                     continueButton
                     AsyncButton(.init("UP_LOGOUT", bundle: .atURL(from: .module)), role: .destructive, state: $viewState) {
-                        let service = account.accountService
-                        try await service.logout()
+                        try await account.accountService.logout()
                     }
                         .environment(\.defaultErrorDescription, .init("UP_LOGOUT_FAILED_DEFAULT_ERROR", bundle: .atURL(from: .module)))
                         .padding(8)

--- a/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
@@ -175,8 +175,14 @@ public struct FollowUpInfoSheet: View {
 
         account.logger.debug("Finished additional account setup. Saving \(detailsBuilder.count) changes!")
 
-        let service = account.accountService
-        try await service.updateAccountDetails(modifications)
+        do {
+            try await account.accountService.updateAccountDetails(modifications)
+        } catch {
+            if error is CancellationError {
+                return
+            }
+            throw error
+        }
 
         onComplete(modifications)
 

--- a/Tests/SpeziAccountTests/AccountNotificationsTests.swift
+++ b/Tests/SpeziAccountTests/AccountNotificationsTests.swift
@@ -25,7 +25,7 @@ private final class TestProvider: AccountStorageProvider {
         XCTFail("\(#function) not implemented")
     }
 
-    func load(_ accountId: String, _ keys: [any SpeziAccount.AccountKey.Type]) async throws -> SpeziAccount.AccountDetails? {
+    func load(_ accountId: String, _ keys: [any SpeziAccount.AccountKey.Type]) async -> SpeziAccount.AccountDetails? {
         XCTFail("\(#function) not implemented")
         return nil
     }


### PR DESCRIPTION
# Handle CancellationError from account services

## :recycle: Current situation & Problem
This PR changes how `CancellationError`s are handled that are returned from an account service. For example, if the `delete()` method of an account service returns an CancellationError we will not show an error dialog but just return to the account overview without dismissing the account overview.


## :gear: Release Notes 
* Handle CancellationErrors thrown from the account service operations.
* Do not allow AccountStorageProvider/load method to be throwing to make it easier for Account Services to interact storage providers.

## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
