### PR TITLE
Upgrade to Swift Syntax for Swift 6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,16 +33,6 @@ jobs:
       destination: 'platform=macOS,arch=arm64'
       artifactname: SpeziAccount-macOS.xcresult
       resultBundle: SpeziAccount-macOS.xcresult
-  buildandtest_ios_latest:
-    name: Build and Test Swift Package iOS Latest
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziAccount
-      xcodeversion: latest
-      swiftVersion: 6
-      artifactname: SpeziAccount-Latest.xcresult
-      resultBundle: SpeziAccount-Latest.xcresult
   buildandtest_visionos:
     name: Build and Test Swift Package visionOS
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -61,17 +51,6 @@ jobs:
       scheme: TestApp
       artifactname: TestApp-iOS.xcresult
       resultBundle: TestApp-iOS.xcresult
-  buildandtestuitests_ios_latest:
-    name: Build and Test UI Tests Latest
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      path: 'Tests/UITests'
-      scheme: TestApp
-      xcodeversion: latest
-      swiftVersion: 6
-      artifactname: TestApp-iOS-Latest.xcresult
-      resultBundle: TestApp-iOS-Latest.xcresult
   buildandtestuitests_visionos:
     name: Build and Test UI Tests visionOS
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2

--- a/Package.swift
+++ b/Package.swift
@@ -32,15 +32,15 @@ let package = Package(
         .library(name: "SpeziAccount", targets: ["SpeziAccount"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.2"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.6.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage", from: "1.2.0"),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.1.1"),
-        .package(url: "https://github.com/apple/swift-collections", from: "1.1.2"),
-        .package(url: "https://github.com/apple/swift-atomics", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0-prerelease-2024-08-14"),
-        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.0-beta.2"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.3"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.6.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "1.2.0"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-prerelease-2024-08-14"),
+        .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0")
     ] + swiftLintPackage(),
     targets: [
         .macro(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Spezi open source project
@@ -11,13 +11,6 @@
 import CompilerPluginSupport
 import class Foundation.ProcessInfo
 import PackageDescription
-
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -50,9 +43,6 @@ let package = Package(
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
                 .product(name: "SwiftDiagnostics", package: "swift-syntax")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -73,9 +63,6 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -87,9 +74,6 @@ let package = Package(
                 .product(name: "XCTSpezi", package: "Spezi"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -98,9 +82,6 @@ let package = Package(
                 "SpeziAccountMacros",
                 .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-            ],
-            swiftSettings: [
-                swiftConcurrency
             ],
             plugins: [] + swiftLintPlugin()
         )

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.1.1"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "510.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0-prerelease-2024-08-14"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", from: "1.17.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/AccountServiceButton.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/AccountServiceButton.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 
 public struct AccountServiceButton<Label: View>: View {
-    private let action: () async throws -> Void
+    private let action: @MainActor () async throws -> Void
     private let label: Label
 
     @Binding private var state: ViewState
@@ -31,7 +31,7 @@ public struct AccountServiceButton<Label: View>: View {
     public init(
         _ titleKey: LocalizedStringResource,
         systemImage: String = "person.crop.square",
-        action: @escaping () async -> Void
+        action: @escaping @MainActor  () async -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
         self.init(titleKey, systemImage: systemImage, state: .constant(.idle), action: action)
     }
@@ -40,7 +40,7 @@ public struct AccountServiceButton<Label: View>: View {
         _ titleKey: LocalizedStringResource,
         systemImage: String = "person.crop.square",
         state: Binding<ViewState>,
-        action: @escaping () async throws -> Void
+        action: @escaping @MainActor  () async throws -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
         self.init(state: state, action: action) {
             SwiftUI.Label {
@@ -54,7 +54,7 @@ public struct AccountServiceButton<Label: View>: View {
     public init(
         _ titleKey: LocalizedStringResource,
         image: ImageResource,
-        action: @escaping () async -> Void
+        action: @escaping @MainActor () async -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
         self.init(titleKey, image: image, state: .constant(.idle), action: action)
     }
@@ -63,7 +63,7 @@ public struct AccountServiceButton<Label: View>: View {
         _ titleKey: LocalizedStringResource,
         image: ImageResource,
         state: Binding<ViewState>,
-        action: @escaping () async throws -> Void
+        action: @escaping @MainActor () async throws -> Void
     ) where Label == SwiftUI.Label<Text, Image> {
         self.init(state: state, action: action) {
             SwiftUI.Label {
@@ -75,7 +75,7 @@ public struct AccountServiceButton<Label: View>: View {
     }
 
     public init(
-        action: @escaping () async -> Void,
+        action: @escaping @MainActor () async -> Void,
         @ViewBuilder label: () -> Label
     ) {
         self.init(state: .constant(.idle), action: action, label: label)
@@ -83,7 +83,7 @@ public struct AccountServiceButton<Label: View>: View {
 
     public init(
         state: Binding<ViewState>,
-        action: @escaping () async throws -> Void,
+        action: @escaping @MainActor () async throws -> Void,
         @ViewBuilder label: () -> Label
     ) {
         self.action = action

--- a/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/SignupSetupView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/SignupSetupView.swift
@@ -55,20 +55,20 @@ struct SignupSetupView<Credential: Sendable>: View {
 
 #if DEBUG
 #Preview {
-    @State var style: PresentedSetupStyle<UserIdPasswordCredential> = .signup
-    @State var presentingSignup = false
+    @Previewable @State var style: PresentedSetupStyle<UserIdPasswordCredential> = .signup
+    @Previewable @State var presentingSignup = false
 
-    return SignupSetupView(style: $style, login: { _ in }, presentingSignup: $presentingSignup)
+    SignupSetupView(style: $style, login: { _ in }, presentingSignup: $presentingSignup)
         .previewWith {
             AccountConfiguration(service: InMemoryAccountService())
         }
 }
 
 #Preview {
-    @State var style: PresentedSetupStyle<UserIdPasswordCredential> = .signup
-    @State var presentingSignup = false
+    @Previewable @State var style: PresentedSetupStyle<UserIdPasswordCredential> = .signup
+    @Previewable @State var presentingSignup = false
 
-    return SignupSetupView(style: $style, login: nil, presentingSignup: $presentingSignup)
+    SignupSetupView(style: $style, login: nil, presentingSignup: $presentingSignup)
         .previewWith {
             AccountConfiguration(service: InMemoryAccountService())
         }

--- a/Sources/SpeziAccount/Views/DataEntry/BoolEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/BoolEntryView.swift
@@ -50,15 +50,15 @@ extension AccountKey where Value == Bool {
 
 #if DEBUG
 #Preview {
-    @State var value = false
-    return Form {
+    @Previewable @State var value = false
+    Form {
         BoolEntryView<MockBoolKey>($value)
     }
 }
 
 #Preview {
-    @State var value = true
-    return Form {
+    @Previewable @State var value = true
+    Form {
         BoolEntryView<MockBoolKey>($value)
     }
 }

--- a/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
@@ -87,9 +87,9 @@ extension AccountKey where Value: PickerValue, Value.AllCases: RandomAccessColle
 
 #if DEBUG
 #Preview {
-    @State var genderIdentity: GenderIdentity = .male
+    @Previewable @State var genderIdentity: GenderIdentity = .male
 
-    return Form {
+    Form {
         Grid {
             CaseIterablePickerEntryView(\.genderIdentity, $genderIdentity)
         }
@@ -97,9 +97,9 @@ extension AccountKey where Value: PickerValue, Value.AllCases: RandomAccessColle
 }
 
 #Preview {
-    @State var genderIdentity: GenderIdentity = .male
+    @Previewable @State var genderIdentity: GenderIdentity = .male
 
-    return Grid {
+    Grid {
         CaseIterablePickerEntryView(\.genderIdentity, $genderIdentity)
     }
         .padding(32)

--- a/Sources/SpeziAccount/Views/DataEntry/FixedWidthIntegerEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/FixedWidthIntegerEntryView.swift
@@ -93,8 +93,8 @@ extension AccountKey where Value: FixedWidthInteger {
 
 #if DEBUG
 #Preview {
-    @State var value = 3
-    return List {
+    @Previewable @State var value = 3
+    List {
         FixedWidthIntegerEntryView<MockNumericKey>($value)
     }
         .previewWith {

--- a/Sources/SpeziAccount/Views/DataEntry/FloatingPointEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/FloatingPointEntryView.swift
@@ -143,8 +143,8 @@ extension AccountKey where Value: BinaryFloatingPoint {
 
 #if DEBUG
 #Preview {
-    @State var value = 3.15
-    return List {
+    @Previewable @State var value = 3.15
+    List {
         FloatingPointEntryView<MockDoubleKey>($value)
     }
         .previewWith {

--- a/Sources/SpeziAccount/Views/DataEntry/StringEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/StringEntryView.swift
@@ -46,8 +46,8 @@ extension AccountKey where Value == String {
 
 #if DEBUG
 #Preview {
-    @State var value = "Hello World"
-    return List {
+    @Previewable @State var value = "Hello World"
+    List {
         StringEntryView(\.userId, $value)
             .validate(input: value, rules: .nonEmpty)
     }

--- a/Sources/SpeziAccountMacros/AccountKeyMacro.swift
+++ b/Sources/SpeziAccountMacros/AccountKeyMacro.swift
@@ -83,14 +83,14 @@ extension AccountKeyMacro: PeerMacro {
               extensionIdentifier.name == "AccountDetails" else {
             throw DiagnosticsError(
                 syntax: declaration,
-                message: "'@AccountKey' can only be applied to 'var' declarations inside of 'AccountDetails'",
+                message: "'@AccountKey' can only be applied to 'var' declarations inside of an extension to 'AccountDetails'",
                 id: .invalidSyntax
             )
         }
 #endif
 
         guard let typeAnnotation = binding.typeAnnotation else {
-            throw DiagnosticsError(syntax: binding, message: "Variable binding is missing the type annotation", id: .invalidSyntax)
+            throw DiagnosticsError(syntax: binding, message: "Variable binding is missing a type annotation", id: .invalidSyntax)
         }
 
         guard case let .argumentList(argumentList) = node.arguments else {

--- a/Sources/SpeziAccountMacros/AccountKeyMacro.swift
+++ b/Sources/SpeziAccountMacros/AccountKeyMacro.swift
@@ -142,7 +142,7 @@ extension AccountKeyMacro: PeerMacro {
 
 
         let modifier: TokenSyntax? = variableDeclaration.modifiers
-            .compactMap { modifier in
+            .compactMap { (modifier: DeclModifierSyntax) -> TokenSyntax? in
                 guard case let .keyword(keyword) = modifier.name.tokenKind else {
                     return nil
                 }

--- a/Sources/SpeziAccountMacros/AccountKeyMacro.swift
+++ b/Sources/SpeziAccountMacros/AccountKeyMacro.swift
@@ -74,8 +74,10 @@ extension AccountKeyMacro: PeerMacro {
             )
         }
 
+#if compiler(>=6)
+        // with previous compilers the `lexicalContext` is empty
         guard let rootContext = context.lexicalContext.first,
-                let extensionDecl = rootContext.as(ExtensionDeclSyntax.self),
+              let extensionDecl = rootContext.as(ExtensionDeclSyntax.self),
               let extendedTypeIdentifier = extensionDecl.extendedType.as(IdentifierTypeSyntax.self),
               let extensionIdentifier = extendedTypeIdentifier.name.identifier,
               extensionIdentifier.name == "AccountDetails" else {
@@ -85,6 +87,7 @@ extension AccountKeyMacro: PeerMacro {
                 id: .invalidSyntax
             )
         }
+#endif
 
         guard let typeAnnotation = binding.typeAnnotation else {
             throw DiagnosticsError(syntax: binding, message: "Variable binding is missing the type annotation", id: .invalidSyntax)

--- a/Sources/SpeziAccountMacros/AccountKeyMacro.swift
+++ b/Sources/SpeziAccountMacros/AccountKeyMacro.swift
@@ -93,6 +93,10 @@ extension AccountKeyMacro: PeerMacro {
             throw DiagnosticsError(syntax: binding, message: "Variable binding is missing a type annotation", id: .invalidSyntax)
         }
 
+        if let initializer = binding.initializer {
+            throw DiagnosticsError(syntax: initializer, message: "Variable binding cannot have a initializer", id: .invalidSyntax)
+        }
+
         guard case let .argumentList(argumentList) = node.arguments else {
             throw DiagnosticsError(syntax: node, message: "Unexpected arguments passed to '@AccountKey'", id: .invalidSyntax)
         }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -33,10 +33,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -75,10 +75,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -111,10 +111,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -147,10 +147,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self [__Key_accountId.self]
+                        self[__Key_accountId.self]
                     }
                     set {
-                        self [__Key_accountId.self] = newValue
+                        self[__Key_accountId.self] = newValue
                     }
                 }
             
@@ -180,10 +180,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self [__Key_accountId.self]
+                        self[__Key_accountId.self]
                     }
                     set {
-                        self [__Key_accountId.self] = newValue
+                        self[__Key_accountId.self] = newValue
                     }
                 }
             }
@@ -215,10 +215,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
 
@@ -280,10 +280,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -349,6 +349,66 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
                 }
             }
             """,
+            macros: testMacros
+        )
+    }
+
+
+    func testGeneralDiagnostics() { // swiftlint:disable:this function_body_length
+        assertMacroExpansion(
+            """
+            @AccountKey(
+                name: "Gender Identity",
+                category: .personalDetails,
+                as: GenderIdentity.self,
+                initial: .default(.preferNotToState),
+                displayView: DataDisplay.self,
+                entryView: DataEntry.self
+            )
+            extension AccountDetails {
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "'@AccountKey' can only be applied to a 'var' declaration", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            """
+            extension NotAccountDetails {
+                @AccountKey(
+                    name: "Gender Identity",
+                    category: .personalDetails,
+                    as: GenderIdentity.self,
+                    initial: .default(.preferNotToState),
+                    displayView: DataDisplay.self,
+                    entryView: DataEntry.self
+                )
+                var genderIdentity: GenderIdentity?
+            }
+            """,
+            expandedSource:
+            """
+            extension NotAccountDetails {
+                var genderIdentity: GenderIdentity? {
+                    get {
+                        self[__Key_genderIdentity.self]
+                    }
+                    set {
+                        self[__Key_genderIdentity.self] = newValue
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "'@AccountKey' can only be applied to 'var' declarations inside of 'AccountDetails'", line: 2, column: 5)
+            ],
             macros: testMacros
         )
     }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -398,16 +398,46 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension NotAccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
             }
             """,
             diagnostics: [
-                DiagnosticSpec(message: "'@AccountKey' can only be applied to 'var' declarations inside of 'AccountDetails'", line: 2, column: 5)
+                DiagnosticSpec(
+                    message: "'@AccountKey' can only be applied to 'var' declarations inside of an extension to 'AccountDetails'",
+                    line: 2,
+                    column: 5
+                )
+            ],
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Gender Identity", category: .personalDetails, as: GenderIdentity.self, initial: .default(.preferNotToState))
+                var genderIdentity: GenderIdentity? = .male
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var genderIdentity: GenderIdentity? {
+                    get {
+                        self [__Key_genderIdentity.self]
+                    }
+                    set {
+                        self [__Key_genderIdentity.self] = newValue
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "Variable binding cannot have a initializer", line: 3, column: 41)
             ],
             macros: testMacros
         )

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -33,10 +33,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -75,10 +75,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -111,10 +111,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -147,10 +147,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self [__Key_accountId.self]
+                        self[__Key_accountId.self]
                     }
                     set {
-                        self [__Key_accountId.self] = newValue
+                        self[__Key_accountId.self] = newValue
                     }
                 }
             
@@ -180,10 +180,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self [__Key_accountId.self]
+                        self[__Key_accountId.self]
                     }
                     set {
-                        self [__Key_accountId.self] = newValue
+                        self[__Key_accountId.self] = newValue
                     }
                 }
             }
@@ -215,10 +215,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
 
@@ -280,10 +280,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -398,10 +398,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension NotAccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             }
@@ -428,10 +428,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self [__Key_genderIdentity.self]
+                        self[__Key_genderIdentity.self]
                     }
                     set {
-                        self [__Key_genderIdentity.self] = newValue
+                        self[__Key_genderIdentity.self] = newValue
                     }
                 }
             }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -33,10 +33,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -75,10 +75,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -111,10 +111,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
             
@@ -147,10 +147,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self[__Key_accountId.self]
+                        self [__Key_accountId.self]
                     }
                     set {
-                        self[__Key_accountId.self] = newValue
+                        self [__Key_accountId.self] = newValue
                     }
                 }
             
@@ -180,10 +180,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var accountId: String {
                     get {
-                        self[__Key_accountId.self]
+                        self [__Key_accountId.self]
                     }
                     set {
-                        self[__Key_accountId.self] = newValue
+                        self [__Key_accountId.self] = newValue
                     }
                 }
             }
@@ -215,10 +215,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 public var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
 
@@ -280,10 +280,10 @@ final class AccountKeyMacroTests: XCTestCase { // swiftlint:disable:this type_bo
             extension AccountDetails {
                 var genderIdentity: GenderIdentity? {
                     get {
-                        self[__Key_genderIdentity.self]
+                        self [__Key_genderIdentity.self]
                     }
                     set {
-                        self[__Key_genderIdentity.self] = newValue
+                        self [__Key_genderIdentity.self] = newValue
                     }
                 }
             

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -238,7 +238,6 @@
 				};
 			};
 			buildConfigurationList = 2F6D138D28F5F384007C25D6 /* Build configuration list for PBXProject "UITests" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -250,6 +249,7 @@
 				2F027C9929D6C91D00234098 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 				A969240D2A9A198800E2128B /* XCRemoteSwiftPackageReference "swift-argument-parser" */,
 			);
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -383,6 +383,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -439,6 +440,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -626,6 +628,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Test;
 		};


### PR DESCRIPTION
# Upgrade to Swift Syntax for Swift 6

## :recycle: Current situation & Problem
This PR upgrades to the upcoming release of SwiftSyntax. This allows us to provide additional functionality like verifying the `lexicalContext` of an account details property. This way, we can check that the `@AccountKey` macro can only be applied inside an extension to `AccountDetails`.


## :gear: Release Notes 
* Improve diagnostics around the `@AccountKey` macro.

## :books: Documentation
--

## :white_check_mark: Testing
Added additional unit tests to verify the updated diagnostics.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
