### PR TITLE
Make AccountConfiguration non-generic, introduce XCTSpeziAccount

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziAccount
+      scheme: SpeziAccount-Package
       artifactname: SpeziAccount.xcresult
       resultBundle: SpeziAccount.xcresult
   buildandtest_macos:
@@ -29,7 +29,7 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziAccount
+      scheme: SpeziAccount-Package
       destination: 'platform=macOS,arch=arm64'
       artifactname: SpeziAccount-macOS.xcresult
       resultBundle: SpeziAccount-macOS.xcresult
@@ -38,7 +38,7 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziAccount
+      scheme: SpeziAccount-Package
       destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
       resultBundle: SpeziAccount-visionOS.xcresult
       artifactname: SpeziAccount-visionOS.xcresult

--- a/.spi.yml
+++ b/.spi.yml
@@ -12,3 +12,4 @@ builder:
     - platform: ios
       documentation_targets:
       - SpeziAccount
+      - XCTSpeziAccount

--- a/Package.swift
+++ b/Package.swift
@@ -26,9 +26,9 @@ let package = Package(
         .library(name: "XCTSpeziAccount", targets: ["XCTSpeziAccount"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.0-beta.2"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.0"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", branch: "feature/additional-infrastructure"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.7.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "1.2.0"),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,14 +22,16 @@ let package = Package(
         .visionOS(.v1)
     ],
     products: [
-        .library(name: "SpeziAccount", targets: ["SpeziAccount"])
+        .library(name: "SpeziAccount", targets: ["SpeziAccount"]),
+        .library(name: "XCTSpeziAccount", targets: ["XCTSpeziAccount"])
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.0-beta.2"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.3"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.6.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", branch: "feature/additional-infrastructure"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "1.2.0"),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
+        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-prerelease-2024-08-14"),
@@ -62,6 +64,14 @@ let package = Package(
             ],
             resources: [
                 .process("Resources")
+            ],
+            plugins: [] + swiftLintPlugin()
+        ),
+        .target(
+            name: "XCTSpeziAccount",
+            dependencies: [
+                .target(name: "SpeziAccount"),
+                .product(name: "XCTestExtensions", package: "XCTestExtensions")
             ],
             plugins: [] + swiftLintPlugin()
         ),

--- a/Sources/SpeziAccount/AccountValue/Collections/AccountDetails+TestingSupport.swift
+++ b/Sources/SpeziAccount/AccountValue/Collections/AccountDetails+TestingSupport.swift
@@ -1,0 +1,29 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+@_spi(TestingSupport)
+extension AccountDetails {
+    static func createMock(
+        id: String = UUID().uuidString,
+        userId: String = "lelandstanford@stanford.edu",
+        name: PersonNameComponents? = PersonNameComponents(givenName: "Leland", familyName: "Stanford"),
+        genderIdentity: GenderIdentity? = nil,
+        dateOfBirth: Date? = nil
+    ) -> AccountDetails {
+        var details = AccountDetails()
+        details.accountId = id
+        details.userId = userId
+        details.name = name
+        details.genderIdentity = genderIdentity
+        details.dateOfBirth = dateOfBirth
+        return details
+    }
+}

--- a/Sources/SpeziAccount/Environment/AccountRequiredKey.swift
+++ b/Sources/SpeziAccount/Environment/AccountRequiredKey.swift
@@ -17,7 +17,7 @@ struct AccountRequiredKey: EnvironmentKey {
 extension EnvironmentValues {
     /// An environment variable that indicates if an account was configured to be required for the app.
     ///
-    /// Fore more information have a look at ``SwiftUI/View/accountRequired(_:considerAnonymousAccounts:setupSheet:)``.
+    /// Fore more information have a look at ``SwiftUICore/View/accountRequired(_:considerAnonymousAccounts:setupSheet:)``.
     public var accountRequired: Bool {
         get {
             self[AccountRequiredKey.self]

--- a/Sources/SpeziAccount/Environment/AccountViewType.swift
+++ b/Sources/SpeziAccount/Environment/AccountViewType.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// Defines the type of `SpeziAccount` view a ``DataEntryView`` or ``DataDisplayView`` is placed in.
 ///
-/// Access this property inside supporting views using the ``SwiftUI/EnvironmentValues/accountViewType`` environment key.
+/// Access this property inside supporting views using the ``SwiftUICore/EnvironmentValues/accountViewType`` environment key.
 ///
 /// ```swift
 /// struct MyView: View {

--- a/Sources/SpeziAccount/Environment/FollowUpBehavior.swift
+++ b/Sources/SpeziAccount/Environment/FollowUpBehavior.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 /// Determine how the Follow-Up information sheet is presented after account setup.
 ///
-/// Use the ``SwiftUI/View/followUpBehaviorAfterSetup(_:)`` modifier to set how the follow-up information sheet is
+/// Use the ``SwiftUICore/View/followUpBehaviorAfterSetup(_:)`` modifier to set how the follow-up information sheet is
 /// shown inside the ``AccountSetup`` after a successful setup (login or signup).
 public enum FollowUpBehavior {
     /// Follow up information will never be asked for after account setup.

--- a/Sources/SpeziAccount/Environment/PreferredSetupStyle.swift
+++ b/Sources/SpeziAccount/Environment/PreferredSetupStyle.swift
@@ -15,7 +15,7 @@ import SwiftUI
 /// In some situations, views might be able to present themselves such that login or signup operations are favored.
 /// For example, an `AccountSetup` view that is displayed in the onboarding flow, might favor a presentation that highlights signup functionality.
 ///
-/// - Note: Use the ``SwiftUI/View/preferredAccountSetupStyle(_:)`` to set the preferred account setup style.
+/// - Note: Use the ``SwiftUICore/View/preferredAccountSetupStyle(_:)`` to set the preferred account setup style.
 public enum PreferredSetupStyle {
     /// Let the view automatically decide on how to present itself.
     ///

--- a/Sources/SpeziAccount/Environment/SignupProviderCompliance.swift
+++ b/Sources/SpeziAccount/Environment/SignupProviderCompliance.swift
@@ -47,7 +47,7 @@ private struct SignupProviderComplianceKey: PreferenceKey {
 ///
 /// The `SignupProviderCompliance` is used by the ``AccountSetup`` view to reason about the compliance of the signup provider.
 ///
-/// Use the ``SwiftUI/View/reportSignupProviderCompliance(_:)`` to set the compliance for your custom signup provider, if necessary.
+/// Use the ``SwiftUICore/View/reportSignupProviderCompliance(_:)`` to set the compliance for your custom signup provider, if necessary.
 ///
 /// - Note: The compliance preference is automatically set when using the ``SignupForm`` or the ``SignInWithAppleButton``.
 public struct SignupProviderCompliance {

--- a/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
@@ -143,7 +143,7 @@ A ``AccountKey/DataEntry`` view is automatically provide if:
     A simple number entry will appear. You have to implement your own view if you have special formatting requirements.
 * The `Value` is a [`BinaryFloatingPoint`](https://developer.apple.com/documentation/swift/binaryfloatingpoint) (e.g., `Double` or `Float`).
     A simple decimal entry will appear. You have to implement your own view if you have special formatting requirements.
-* The `Value` conforms to the ``PickerValue`` protocols. This is provides a Picker UI for enum types.
+* The `Value` conforms to the `PickerValue` protocols. This is provides a Picker UI for enum types.
     `PickerValue` is shorthand to conform to the [`CaseIterable`](https://developer.apple.com/documentation/swift/caseiterable),
     [`CustomLocalizedStringResourceConvertible`](https://developer.apple.com/documentation/foundation/customlocalizedstringresourceconvertible)
     and [`Hashable`](https://developer.apple.com/documentation/swift/hashable) protocols.
@@ -209,6 +209,6 @@ Still, you are required to evaluate to which extent validation has to be handled
 
 ### Available Environment Keys
 
-- ``SwiftUI/EnvironmentValues/accountViewType``
-- ``SwiftUI/EnvironmentValues/passwordFieldType``
-- ``SwiftUI/EnvironmentValues/accountServiceConfiguration``
+- ``SwiftUICore/EnvironmentValues/accountViewType``
+- ``SwiftUICore/EnvironmentValues/passwordFieldType``
+- ``SwiftUICore/EnvironmentValues/accountServiceConfiguration``

--- a/Sources/SpeziAccount/SpeziAccount.docc/AccountService/Creating your own Account Service.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/AccountService/Creating your own Account Service.md
@@ -250,7 +250,7 @@ actor MyAccountService: AccountService {
 
 ### UI Customization
 
-- ``SwiftUI/View/reportSignupProviderCompliance(_:)``
+- ``SwiftUICore/View/reportSignupProviderCompliance(_:)``
 - ``SignupProviderCompliance``
 
 ### Credentials

--- a/Sources/SpeziAccount/SpeziAccount.docc/SpeziAccount.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/SpeziAccount.md
@@ -78,13 +78,13 @@ Refer to the <doc:Creating-your-own-Account-Service> article if you plan on impl
 - ``AccountOverview``
 - ``AccountHeader``
 - ``FollowUpInfoSheet``
-- ``SwiftUI/View/accountRequired(_:considerAnonymousAccounts:setupSheet:)``
-- ``SwiftUI/EnvironmentValues/accountRequired``
+- ``SwiftUICore/View/accountRequired(_:considerAnonymousAccounts:setupSheet:)``
+- ``SwiftUICore/EnvironmentValues/accountRequired``
 
 ### Environment & Preferences
 
-- ``SwiftUI/View/preferredAccountSetupStyle(_:)``
-- ``SwiftUI/View/followUpBehaviorAfterSetup(_:)``
+- ``SwiftUICore/View/preferredAccountSetupStyle(_:)``
+- ``SwiftUICore/View/followUpBehaviorAfterSetup(_:)``
 
 ### Reacting to Events
 

--- a/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
+++ b/Sources/SpeziAccount/ViewModifier/AccountRequiredModifier.swift
@@ -84,7 +84,7 @@ extension View {
     /// If account requirement is set, this modifier will automatically pop open an account setup sheet if
     /// it is detected that the associated user account was removed.
     ///
-    /// - Note: This modifier injects the ``SwiftUI/EnvironmentValues/accountRequired`` property depending on the `required` argument.
+    /// - Note: This modifier injects the ``SwiftUICore/EnvironmentValues/accountRequired`` property depending on the `required` argument.
     ///
     /// - Parameters:
     ///   - required: The flag indicating if an account is required at all times.

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -84,19 +84,14 @@ struct AccountKeyOverviewRow: View {
 #if DEBUG && !os(macOS)
 private let key = AccountKeys.genderIdentity
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-    details.genderIdentity = .male
-
-    return AccountDetailsReader { account, details in
+    AccountDetailsReader { account, details in
         let model = AccountOverviewFormViewModel(account: account, details: details)
 
         AccountKeyOverviewRow(details: details, for: key, model: model)
             .injectEnvironmentObjects(configuration: details.accountServiceConfiguration, model: model)
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(genderIdentity: .male))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewHeader.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewHeader.swift
@@ -61,10 +61,6 @@ struct AccountOverviewHeader: View {
 
 #if DEBUG
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return AccountOverviewHeader(details: details)
+    AccountOverviewHeader(details: .createMock())
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -321,12 +321,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View { // swiftlint:di
 
 #if DEBUG && !os(macOS)
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-    details.genderIdentity = .male
-
-    return NavigationStack {
+    NavigationStack {
         AccountOverview {
             Section(header: Text(verbatim: "App")) {
                 NavigationLink {
@@ -343,17 +338,12 @@ struct AccountOverviewSections<AdditionalSections: View>: View { // swiftlint:di
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(genderIdentity: .male))
         }
 }
 
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-    details.genderIdentity = .male
-
-    return NavigationStack {
+    NavigationStack {
         AccountOverview(deletion: .belowLogout) {
             Section(header: Text(verbatim: "App")) {
                 NavigationLink {
@@ -370,7 +360,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View { // swiftlint:di
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(genderIdentity: .male))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/NameOverview.swift
@@ -72,31 +72,24 @@ struct NameOverview: View {
 
 #if DEBUG
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return NavigationStack {
+    NavigationStack {
         AccountDetailsReader { account, details in
             NameOverview(model: AccountOverviewFormViewModel(account: account, details: details), details: details)
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock())
         }
 }
 
 #Preview {
-    var detailsWithoutName = AccountDetails()
-    detailsWithoutName.userId = "lelandstanford@stanford.edu"
-
-    return NavigationStack {
+    NavigationStack {
         AccountDetailsReader { account, details in
             NameOverview(model: AccountOverviewFormViewModel(account: account, details: details), details: details)
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: detailsWithoutName)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(name: nil))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/PasswordChangeSheet.swift
@@ -140,18 +140,13 @@ struct PasswordChangeSheet: View {
 
 #if DEBUG
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-    details.genderIdentity = .male
-
-    return NavigationStack {
+    NavigationStack {
         AccountDetailsReader { account, details in
             PasswordChangeSheet(model: AccountOverviewFormViewModel(account: account, details: details), details: details)
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(genderIdentity: .male))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SecurityOverview.swift
@@ -75,18 +75,13 @@ struct SecurityOverview: View {
 
 #if DEBUG && !os(macOS)
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-    details.genderIdentity = .male
-
-    return NavigationStack {
+    NavigationStack {
         AccountDetailsReader { account, details in
             SecurityOverview(model: AccountOverviewFormViewModel(account: account, details: details), details: details)
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(genderIdentity: .male))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/SingleEditView.swift
@@ -91,17 +91,13 @@ struct SingleEditView<Key: AccountKey>: View {
 
 #if DEBUG
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return NavigationStack {
+    NavigationStack {
         AccountDetailsReader { account, details in
             SingleEditView(for: \.name, model: AccountOverviewFormViewModel(account: account, details: details), details: details)
         }
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock())
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/DefaultAccountSetupHeader.swift
@@ -53,12 +53,9 @@ public struct DefaultAccountSetupHeader: View {
 }
 
 #Preview {
-    var details = AccountDetails()
-    details.userId = "myUser"
-
-    return DefaultAccountSetupHeader()
+    DefaultAccountSetupHeader()
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(userId: "myUser", name: nil))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/ExistingAccountView.swift
@@ -57,11 +57,7 @@ struct ExistingAccountView<Continue: View>: View {
 
 #if DEBUG
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return ExistingAccountView(details: details)
+    ExistingAccountView(details: .createMock())
         .padding(.horizontal, ViewSizing.outerHorizontalPadding)
         .previewWith {
             AccountConfiguration(service: InMemoryAccountService())
@@ -69,11 +65,7 @@ struct ExistingAccountView<Continue: View>: View {
 }
 
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-    details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return ExistingAccountView(details: details) {
+    ExistingAccountView(details: .createMock()) {
         Button {
             print("Pressed")
         } label: {

--- a/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
@@ -226,14 +226,11 @@ extension FollowUpInfoSheet.CancelBehavior {
 #if DEBUG
 private let keys: [any AccountKey.Type] = [AccountKeys.name]
 #Preview {
-    var details = AccountDetails()
-    details.userId = "lelandstanford@stanford.edu"
-
-    return NavigationStack {
+    NavigationStack {
         FollowUpInfoSheet(keys: keys)
     }
         .previewWith {
-            AccountConfiguration(service: InMemoryAccountService(), activeDetails: details)
+            AccountConfiguration(service: InMemoryAccountService(), activeDetails: .createMock(name: nil))
         }
 }
 #endif

--- a/Sources/SpeziAccount/Views/AccountSummaryBox.swift
+++ b/Sources/SpeziAccount/Views/AccountSummaryBox.swift
@@ -68,36 +68,22 @@ struct AccountSummaryBox: View {
 
 #if DEBUG
 #Preview {
-    var emailDetails = AccountDetails()
-    emailDetails.userId = "lelandstanford@stanford.edu"
-    emailDetails.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return AccountSummaryBox(details: emailDetails)
+    AccountSummaryBox(details: .createMock())
         .padding(.horizontal, ViewSizing.innerHorizontalPadding)
 }
 
 #Preview {
-    var usernameDetails = AccountDetails()
-    usernameDetails.userId = "leland.stanford"
-    usernameDetails.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
-
-    return AccountSummaryBox(details: usernameDetails)
+    AccountSummaryBox(details: .createMock(userId: "leland.stanford"))
         .padding(.horizontal, ViewSizing.innerHorizontalPadding)
 }
 
 #Preview {
-    var usernameWithoutNameDetails = AccountDetails()
-    usernameWithoutNameDetails.userId = "leland.stanford"
-
-    return AccountSummaryBox(details: usernameWithoutNameDetails)
+    AccountSummaryBox(details: .createMock(userId: "leland.stanford", name: nil))
         .padding(.horizontal, ViewSizing.innerHorizontalPadding)
 }
 
 #Preview {
-    var emailOnlyDetails = AccountDetails()
-    emailOnlyDetails.userId = "lelandstanford@stanford.edu"
-
-    return AccountSummaryBox(details: emailOnlyDetails)
+    AccountSummaryBox(details: .createMock(name: nil))
         .padding(.horizontal, ViewSizing.innerHorizontalPadding)
 }
 #endif

--- a/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
@@ -18,7 +18,7 @@ public struct CaseIterablePickerEntryView<Key: AccountKey>: DataEntryView where 
     @Binding private var value: Key.Value
 
     public var body: some View {
-        CaseIterablePicker(Key.name, value: $value)
+        CaseIterablePicker(Key.name, selection: $value)
     }
 
     /// Create a new entry view.

--- a/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/CaseIterablePickerEntryView.swift
@@ -7,54 +7,13 @@
 //
 
 import SpeziFoundation
+import SpeziViews
 import SwiftUI
-
-
-/// A account value that can be rendered as a picker (like enum values).
-///
-/// In order to provide an Automatic Picker ``DataEntryView``, conform your enum to [`CaseIterable`](https://developer.apple.com/documentation/swift/caseiterable)
-/// to enumerate all cases, [`CustomLocalizedStringResourceConvertible`](https://developer.apple.com/documentation/foundation/customlocalizedstringresourceconvertible)
-/// to provide a localizable representation for each case and [`Hashable`](https://developer.apple.com/documentation/swift/hashable)
-/// to differentiate cases.
-public typealias PickerValue = CaseIterable & CustomLocalizedStringResourceConvertible & Hashable
-
-
-struct CaseIterablePicker<Value: PickerValue, Label: View>: View where Value.AllCases: RandomAccessCollection {
-    private let label: Label
-
-    @Binding private var value: Value
-
-
-    var body: some View {
-        Picker(selection: $value) {
-            ForEach(Value.allCases, id: \.hashValue) { value in
-                Text(value.localizedStringResource)
-                    .tag(value)
-            }
-        } label: {
-            label
-        }
-    }
-
-    init(value: Binding<Value>, @ViewBuilder label: () -> Label) {
-        self._value = value
-        self.label = label()
-    }
-
-    init(_ titleKey: LocalizedStringResource, value: Binding<Value>) where Label == Text {
-        self.init(value: value) {
-            Text(titleKey)
-        }
-    }
-}
 
 
 /// Entry or modify the value of an `PickerValue`-based `AccountKey`.
 ///
-/// For more information, refer to the documentation of ``PickerValue``.
-///
-/// ## Topics
-/// - ``PickerValue``
+/// For more information, refer to the documentation of `PickerValue`.
 public struct CaseIterablePickerEntryView<Key: AccountKey>: DataEntryView where Key.Value: PickerValue, Key.Value.AllCases: RandomAccessCollection {
     @Binding private var value: Key.Value
 
@@ -80,7 +39,7 @@ public struct CaseIterablePickerEntryView<Key: AccountKey>: DataEntryView where 
 
 
 extension AccountKey where Value: PickerValue, Value.AllCases: RandomAccessCollection {
-    /// Default DataEntry view for Values that conform to ``PickerValue`` (typically useful with enums)
+    /// Default DataEntry view for Values that conform to `PickerValue` (typically useful with enums)
     public typealias DataEntry = CaseIterablePickerEntryView<Self>
 }
 

--- a/Sources/SpeziAccount/Views/PasswordResetView.swift
+++ b/Sources/SpeziAccount/Views/PasswordResetView.swift
@@ -164,9 +164,9 @@ public struct PasswordResetView<SuccessView: View>: View {
         PasswordResetView { userId in
             print("Reset password for \(userId)")
         }
-        .previewWith {
-            AccountConfiguration(service: InMemoryAccountService())
-        }
+            .previewWith {
+                AccountConfiguration(service: InMemoryAccountService())
+            }
     }
 }
 
@@ -175,9 +175,9 @@ public struct PasswordResetView<SuccessView: View>: View {
         PasswordResetView(requestSubmitted: true) { userId in
             print("Reset password for \(userId)")
         }
-        .previewWith {
-            AccountConfiguration(service: InMemoryAccountService())
-        }
+            .previewWith {
+                AccountConfiguration(service: InMemoryAccountService())
+            }
     }
 }
 #endif

--- a/Sources/SpeziAccount/Views/Preview/AccountDetailsReader.swift
+++ b/Sources/SpeziAccount/Views/Preview/AccountDetailsReader.swift
@@ -10,21 +10,23 @@
 import SwiftUI
 
 
-#if DEBUG
-struct AccountDetailsReader<Content: View>: View {
-    private let bodyClosure: (Account, AccountDetails) -> Content
+/// Read the account details from the SwiftUI environment.
+@_spi(TestingSupport)
+public struct AccountDetailsReader<Content: View>: View {
+    private let content: (Account, AccountDetails) -> Content
     
     @Environment(Account.self)
     private var account
 
-    var body: some View {
+    public var body: some View {
         if let details = account.details {
-            bodyClosure(account, details)
+            content(account, details)
         }
     }
-
-    init(@ViewBuilder _ bodyClosure: @escaping (Account, AccountDetails) -> Content) {
-        self.bodyClosure = bodyClosure
+    
+    /// Pass in a view builder that receives the account and account details of the environment.
+    /// - Parameter bodyClosure: The view builder.
+    public init(@ViewBuilder _ content: @escaping (Account, AccountDetails) -> Content) {
+        self.content = content
     }
 }
-#endif

--- a/Sources/SpeziAccount/Views/SuccessfulPasswordResetView.swift
+++ b/Sources/SpeziAccount/Views/SuccessfulPasswordResetView.swift
@@ -44,11 +44,9 @@ public struct SuccessfulPasswordResetView: View {
 
 
 #if DEBUG
-struct DefaultSuccessfulPasswordResetView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationStack {
-            SuccessfulPasswordResetView()
-        }
+#Preview {
+    NavigationStack {
+        SuccessfulPasswordResetView()
     }
 }
 #endif

--- a/Sources/XCTSpeziAccount/XCTSpeziAccount.docc/XCTSpeziAccount.md
+++ b/Sources/XCTSpeziAccount/XCTSpeziAccount.docc/XCTSpeziAccount.md
@@ -1,0 +1,17 @@
+# ``XCTSpeziAccount``
+
+Making writing UI Tests for SpeziAccount-related functionality easier.
+
+## Topics
+
+### Login
+
+- ``XCTest/XCUIApplication/login(email:password:)``
+- ``XCTest/XCUIApplication/login(username:password:)``
+
+### Signup Form
+
+- ``XCTest/XCUIApplication/fillSignupForm(email:password:name:genderIdentity:supplyDateOfBirth:)``
+- ``XCTest/XCUIApplication/updateGenderIdentity(from:to:file:line:)``
+- ``XCTest/XCUIApplication/changeDateOfBirth()``
+- ``XCTest/XCUIApplication/closeSignupForm(discardChangesIfAsked:)``

--- a/Sources/XCTSpeziAccount/XCTSpeziAccount.docc/XCTSpeziAccount.md
+++ b/Sources/XCTSpeziAccount/XCTSpeziAccount.docc/XCTSpeziAccount.md
@@ -2,6 +2,16 @@
 
 Making writing UI Tests for SpeziAccount-related functionality easier.
 
+<!--
+
+This source file is part of the Spezi open-source project
+
+SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
 ## Topics
 
 ### Login

--- a/Sources/XCTSpeziAccount/XCUIApplication+AccountValues.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+AccountValues.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Spezi open-source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -10,13 +10,22 @@ import XCTest
 
 
 extension XCUIApplication {
-    func updateGenderIdentity(from: String, to: String, file: StaticString = #filePath, line: UInt = #line) {
+    /// Update the gender identity picker.
+    /// - Parameters:
+    ///   - from: The currently selected value.
+    ///   - to: The new selected value.
+    ///   - file: The file where this is executed.
+    ///   - line: The line where this is executed.
+    public func updateGenderIdentity(from: String, to: String, file: StaticString = #filePath, line: UInt = #line) {
         staticTexts[from].tap()
         XCTAssertTrue(buttons[to].waitForExistence(timeout: 0.5), "Couldn't locate gender identity dropdown", file: file, line: line)
         buttons[to].tap()
     }
-
-    func changeDatePreviousMonthFirstDay() {
+    
+    /// Change the date of birth.
+    ///
+    /// Typically it will select the first day of the previous month. This method will make sure to add a date of birth is none is added yet.
+    public func changeDateOfBirth() {
         // add date button is presented if date is not required or doesn't exists yet
         if buttons["Add Date of Birth"].exists { // uses the accessibility label
             buttons["Add Date of Birth"].tap()

--- a/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+Login.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+
+
+extension XCUIApplication {
+    /// Perform password-credential based login.
+    /// - Parameters:
+    ///   - email: The email credential.
+    ///   - password: The password credential.
+    public func login<Email: StringProtocol, Password: StringProtocol>(email: Email, password: Password) throws {
+        try login(userId: email, password: password, field: "E-Mail Address")
+    }
+    
+    /// Perform password-credential based login.
+    /// - Parameters:
+    ///   - username: The username credential.
+    ///   - password: The password credential.
+    public func login<Username: StringProtocol, Password: StringProtocol>(username: Username, password: Password) throws {
+        try login(userId: username, password: password, field: "Username")
+    }
+
+
+    private func login<UserId: StringProtocol, Password: StringProtocol>(userId: UserId, password: Password, field: String) throws {
+        XCTAssertTrue(textFields[field].exists)
+        XCTAssertTrue(secureTextFields["Password"].exists)
+
+        try textFields[field].enter(value: String(userId))
+        try secureTextFields["Password"].enter(value: String(password))
+
+        XCTAssertTrue(buttons["Login"].waitForExistence(timeout: 0.5)) // might need time to to get enabled
+        XCTAssertTrue(buttons["Login"].isEnabled)
+        buttons["Login"].tap()
+    }
+}

--- a/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
@@ -52,7 +52,7 @@ extension XCUIApplication {
             }
 
 #if os(visionOS)
-            if genderIdentity != nil || supplyDateOfBirth || biography != nil {
+            if genderIdentity != nil || supplyDateOfBirth {
                 scrollUpInSetup()
             }
 #endif
@@ -67,4 +67,24 @@ extension XCUIApplication {
             self.changeDateOfBirth()
         }
     }
+}
+
+
+extension XCUIApplication {
+#if os(visionOS)
+    /// Scrolls up in the  `SignupForm` on visionOS platforms.
+    public func scrollUpInSignupForm() {
+        // swipeUp doesn't work on visionOS, so we improvise
+
+        if staticTexts["Name"].waitForExistence(timeout: 2.0) {
+            XCTAssertTrue(staticTexts["Create a new Account"].exists)
+            staticTexts["Name"].press(forDuration: 0, thenDragTo: staticTexts["Create a new Account"].firstMatch)
+        } else if staticTexts["Personal Details"].exists {
+            XCTAssertTrue(staticTexts["Create a new Account"].exists)
+            staticTexts["Personal Details"].press(forDuration: 0, thenDragTo: staticTexts["Create a new Account"].firstMatch)
+        } else {
+            XCTFail("Could not scroll on visionOS")
+        }
+    }
+#endif
 }

--- a/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the Spezi open-source project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
 // SPDX-License-Identifier: MIT
 //
@@ -10,7 +10,9 @@ import XCTest
 
 
 extension XCUIApplication {
-    func closeSignupForm(discardChangesIfAsked: Bool = true) throws {
+    /// Close the signup form.
+    /// - Parameter discardChangesIfAsked: Confirms to discard all changes if attempting to close the signup form while data was already entered.
+    public func closeSignupForm(discardChangesIfAsked: Bool = true) throws {
         XCTAssertTrue(navigationBars.buttons["Close"].exists)
         try XCTUnwrap(navigationBars.buttons.matching(identifier: "Close").allElementsBoundByIndex.last).tap()
 
@@ -19,14 +21,20 @@ extension XCUIApplication {
             buttons["Discard Input"].tap()
         }
     }
-
-    func fillSignupForm(
+    
+    /// Fill out the signup form.
+    /// - Parameters:
+    ///   - email: The email address to use.
+    ///   - password: The password to use.
+    ///   - name: Optional name.
+    ///   - genderIdentity: Optional gender identity.
+    ///   - supplyDateOfBirth: Optional, specify a date of birth. If `true` this makes sure a date of birth is specified. Typically it will select the first day of the previous month.
+    public func fillSignupForm(
         email: String,
         password: String,
         name: PersonNameComponents? = nil,
         genderIdentity: String? = nil,
-        supplyDateOfBirth: Bool = false,
-        biography: String? = nil
+        supplyDateOfBirth: Bool = false
     ) throws {
         // we access through collectionViews as there is another E-Mail Address and Password field behind the signup sheet
         XCTAssertTrue(collectionViews.textFields["E-Mail Address"].exists, "Couldn't locate E-Mail Address field")
@@ -56,11 +64,7 @@ extension XCUIApplication {
         }
 
         if supplyDateOfBirth {
-            self.changeDatePreviousMonthFirstDay()
-        }
-
-        if let biography {
-            try textFields["Biography"].enter(value: biography)
+            self.changeDateOfBirth()
         }
     }
 }

--- a/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
+++ b/Sources/XCTSpeziAccount/XCUIApplication+SignupForm.swift
@@ -53,7 +53,7 @@ extension XCUIApplication {
 
 #if os(visionOS)
             if genderIdentity != nil || supplyDateOfBirth {
-                scrollUpInSetup()
+                scrollUpInSignupForm()
             }
 #endif
         }

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import XCTestExtensions
+import XCTSpeziAccount
 
 
 final class AccountOverviewTests: XCTestCase { // swiftlint:disable:this type_body_length

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -63,7 +63,7 @@ final class AccountOverviewTests: XCTestCase { // swiftlint:disable:this type_bo
         app.updateGenderIdentity(from: "Male", to: "Choose not to answer")
 #if !os(visionOS)
         // on visionOS we are currently unable to tap on date pickers :)
-        app.changeDatePreviousMonthFirstDay()
+        app.changeDateOfBirth()
 #endif
 
         XCTAssertTrue(app.buttons["Add Biography"].exists)

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 import XCTestExtensions
+import XCTSpeziAccount
 
 
 final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_length
@@ -174,7 +175,7 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         )
 
 #if os(visionOS)
-        app.scrollUpInSetup()
+        app.scrollUpInSignupForm()
 #endif
 
         XCTAssertTrue(app.collectionViews.buttons["Signup"].waitForExistence(timeout: 1.0))
@@ -282,7 +283,7 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         try app.collectionViews.secureTextFields["Password"].enter(value: String(password.dropFirst(4)), options: .skipTextFieldSelection)
 
 #if os(visionOS)
-        app.scrollUpInSetup()
+        app.scrollUpInSignupForm()
 #endif
 
         // we access the signup button through the collectionView as there is another signup button behind the signup sheet.
@@ -311,7 +312,7 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         app.openSignup()
 
 #if os(visionOS)
-        app.scrollUpInSetup()
+        app.scrollUpInSignupForm()
 #endif
 
         XCTAssertTrue(app.collectionViews.buttons["Signup"].exists)
@@ -342,7 +343,7 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         try app.fillSignupForm(email: Defaults.email, password: Defaults.password)
 
 #if os(visionOS)
-        app.scrollUpInSetup()
+        app.scrollUpInSignupForm()
 #endif
 
         XCTAssertTrue(app.collectionViews.buttons["Signup"].waitForExistence(timeout: 1.0))
@@ -473,7 +474,7 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         try app.textFields["enter first name"].delete(count: 6)
 
 #if os(visionOS)
-        app.scrollUpInSetup()
+        app.scrollUpInSignupForm()
 #endif
 
         XCTAssertTrue(app.collectionViews.buttons["Signup"].waitForExistence(timeout: 1.0))
@@ -561,25 +562,6 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
         XCTAssertTrue(app.staticTexts["Spezi Account"].waitForExistence(timeout: 2.0))
         XCTAssertFalse(app.staticTexts["User Id"].exists)
     }
-}
-
-
-extension XCUIApplication {
-#if os(visionOS)
-    func scrollUpInSetup() {
-        // swipeUp doesn't work on visionOS, so we improvise
-
-        if staticTexts["Name"].waitForExistence(timeout: 2.0) {
-            XCTAssertTrue(staticTexts["Create a new Account"].exists)
-            staticTexts["Name"].press(forDuration: 0, thenDragTo: staticTexts["Create a new Account"].firstMatch)
-        } else if staticTexts["Personal Details"].exists {
-            XCTAssertTrue(staticTexts["Create a new Account"].exists)
-            staticTexts["Personal Details"].press(forDuration: 0, thenDragTo: staticTexts["Create a new Account"].firstMatch)
-        } else {
-            XCTFail("Could not scroll on visionOS")
-        }
-    }
-#endif
 }
 
 

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import XCTSpeziAccount
 
 
 extension XCUIApplication {
@@ -17,7 +18,7 @@ extension XCUIApplication {
         XCTAssertTrue(staticTexts["Please fill out the details below to create your new account."].waitForExistence(timeout: 3.0))
     }
 
-    func fillSignupForm(
+    func fillSignupForm( // swiftlint:disable:this function_default_parameter_at_end
         email: String,
         password: String,
         name: PersonNameComponents? = nil,
@@ -25,10 +26,14 @@ extension XCUIApplication {
         supplyDateOfBirth: Bool = false,
         biography: String
     ) throws {
-        fillSignupForm(email: email, password: password, name: name, genderIdentity: genderIdentity, supplyDateOfBirth: supplyDateOfBirth)
+        try fillSignupForm(email: email, password: password, name: name, genderIdentity: genderIdentity, supplyDateOfBirth: supplyDateOfBirth)
 
-        if let biography {
-            try textFields["Biography"].enter(value: biography)
+#if os(visionOS)
+        if name != nil && genderIdentity == nil && !supplyDateOfBirth {
+            scrollUpInSignupForm() // fillSignupForm didn't scroll, so we need to here
         }
+#endif
+
+        try textFields["Biography"].enter(value: biography)
     }
 }

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
@@ -10,31 +10,25 @@ import XCTest
 
 
 extension XCUIApplication {
-    func login<Email: StringProtocol, Password: StringProtocol>(email: Email, password: Password) throws {
-        try login(userId: email, password: password, field: "E-Mail Address")
-    }
-
-    func login<Username: StringProtocol, Password: StringProtocol>(username: Username, password: Password) throws {
-        try login(userId: username, password: password, field: "Username")
-    }
-
-
-    private func login<UserId: StringProtocol, Password: StringProtocol>(userId: UserId, password: Password, field: String) throws {
-        XCTAssertTrue(textFields[field].exists)
-        XCTAssertTrue(secureTextFields["Password"].exists)
-
-        try textFields[field].enter(value: String(userId))
-        try secureTextFields["Password"].enter(value: String(password))
-
-        XCTAssertTrue(buttons["Login"].waitForExistence(timeout: 0.5)) // might need time to to get enabled
-        XCTAssertTrue(buttons["Login"].isEnabled)
-        buttons["Login"].tap()
-    }
-
     func openSignup() {
         XCTAssertTrue(buttons["Signup"].waitForExistence(timeout: 3.0))
         buttons["Signup"].tap()
 
         XCTAssertTrue(staticTexts["Please fill out the details below to create your new account."].waitForExistence(timeout: 3.0))
+    }
+
+    func fillSignupForm(
+        email: String,
+        password: String,
+        name: PersonNameComponents? = nil,
+        genderIdentity: String? = nil,
+        supplyDateOfBirth: Bool = false,
+        biography: String
+    ) throws {
+        fillSignupForm(email: email, password: password, name: name, genderIdentity: genderIdentity, supplyDateOfBirth: supplyDateOfBirth)
+
+        if let biography {
+            try textFields["Biography"].enter(value: biography)
+        }
     }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -19,14 +19,13 @@
 		A969240F2A9A198800E2128B /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = A969240E2A9A198800E2128B /* ArgumentParser */; };
 		A98739032C64EE6000E17A42 /* EntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98739022C64EE5F00E17A42 /* EntryViewTests.swift */; };
 		A98739052C64F1BB00E17A42 /* EntryViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98739042C64F1B300E17A42 /* EntryViewsTests.swift */; };
+		A994264B2CD25C50002F8BD5 /* XCTSpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = A994264A2CD25C50002F8BD5 /* XCTSpeziAccount */; };
 		A9B6E3F72A9B6F5B0008B232 /* AccountSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3F62A9B6F5B0008B232 /* AccountSetupTests.swift */; };
 		A9B6E3F92A9B6F660008B232 /* AccountOverviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3F82A9B6F660008B232 /* AccountOverviewTests.swift */; };
 		A9B6E3FB2A9B70360008B232 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3FA2A9B70360008B232 /* Defaults.swift */; };
 		A9B6E3FD2A9B74830008B232 /* BiographyKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3FC2A9B74830008B232 /* BiographyKey.swift */; };
 		A9B6E3FF2A9B795C0008B232 /* TestStandard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E3FE2A9B795C0008B232 /* TestStandard.swift */; };
-		A9B6E4032A9BB2720008B232 /* XCUIApplication+AccountValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E4022A9BB2720008B232 /* XCUIApplication+AccountValues.swift */; };
 		A9B6E4052A9BB27A0008B232 /* XCUIApplication+AccountSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E4042A9BB27A0008B232 /* XCUIApplication+AccountSetup.swift */; };
-		A9B6E4072A9BB2830008B232 /* XCUIApplication+SignupForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E4062A9BB2830008B232 /* XCUIApplication+SignupForm.swift */; };
 		A9B6E40B2A9BB2980008B232 /* XCUIApplication+TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B6E40A2A9BB2980008B232 /* XCUIApplication+TestApp.swift */; };
 		A9EE7D282A3357D900C2B9A9 /* DocumentationHintsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D272A3357D900C2B9A9 /* DocumentationHintsTests.swift */; };
 		A9EE7D2A2A3359E800C2B9A9 /* Features.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EE7D292A3359E800C2B9A9 /* Features.swift */; };
@@ -63,9 +62,7 @@
 		A9B6E3FA2A9B70360008B232 /* Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Defaults.swift; sourceTree = "<group>"; };
 		A9B6E3FC2A9B74830008B232 /* BiographyKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiographyKey.swift; sourceTree = "<group>"; };
 		A9B6E3FE2A9B795C0008B232 /* TestStandard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStandard.swift; sourceTree = "<group>"; };
-		A9B6E4022A9BB2720008B232 /* XCUIApplication+AccountValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+AccountValues.swift"; sourceTree = "<group>"; };
 		A9B6E4042A9BB27A0008B232 /* XCUIApplication+AccountSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+AccountSetup.swift"; sourceTree = "<group>"; };
-		A9B6E4062A9BB2830008B232 /* XCUIApplication+SignupForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+SignupForm.swift"; sourceTree = "<group>"; };
 		A9B6E40A2A9BB2980008B232 /* XCUIApplication+TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+TestApp.swift"; sourceTree = "<group>"; };
 		A9EE7D272A3357D900C2B9A9 /* DocumentationHintsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DocumentationHintsTests.swift; sourceTree = "<group>"; };
 		A9EE7D292A3359E800C2B9A9 /* Features.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Features.swift; sourceTree = "<group>"; };
@@ -85,6 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A994264B2CD25C50002F8BD5 /* XCTSpeziAccount in Frameworks */,
 				2F027C9B29D6C91E00234098 /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -164,9 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				A9B6E3FA2A9B70360008B232 /* Defaults.swift */,
-				A9B6E4022A9BB2720008B232 /* XCUIApplication+AccountValues.swift */,
 				A9B6E4042A9BB27A0008B232 /* XCUIApplication+AccountSetup.swift */,
-				A9B6E4062A9BB2830008B232 /* XCUIApplication+SignupForm.swift */,
 				A9B6E40A2A9BB2980008B232 /* XCUIApplication+TestApp.swift */,
 			);
 			path = Utils;
@@ -212,6 +208,7 @@
 			name = TestAppUITests;
 			packageProductDependencies = (
 				2F027C9A29D6C91E00234098 /* XCTestExtensions */,
+				A994264A2CD25C50002F8BD5 /* XCTSpeziAccount */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
@@ -225,7 +222,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1610;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -304,9 +301,7 @@
 				A9B6E3FB2A9B70360008B232 /* Defaults.swift in Sources */,
 				A9EE7D282A3357D900C2B9A9 /* DocumentationHintsTests.swift in Sources */,
 				2F027C9D29D6CA1100234098 /* XCUIApplication+TestPrimaryButton.swift in Sources */,
-				A9B6E4072A9BB2830008B232 /* XCUIApplication+SignupForm.swift in Sources */,
 				A9B6E40B2A9BB2980008B232 /* XCUIApplication+TestApp.swift in Sources */,
-				A9B6E4032A9BB2720008B232 /* XCUIApplication+AccountValues.swift in Sources */,
 				A9B6E4052A9BB27A0008B232 /* XCUIApplication+AccountSetup.swift in Sources */,
 				A9B6E3F92A9B6F660008B232 /* AccountOverviewTests.swift in Sources */,
 			);
@@ -476,7 +471,6 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
@@ -513,7 +507,6 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
@@ -522,7 +515,6 @@
 		2F6D13BD28F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -537,7 +529,6 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_TARGET_NAME = TestApp;
 				XROS_DEPLOYMENT_TARGET = 1.0;
@@ -547,7 +538,6 @@
 		2F6D13BE28F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -561,7 +551,6 @@
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_TARGET_NAME = TestApp;
 				XROS_DEPLOYMENT_TARGET = 1.0;
@@ -663,7 +652,6 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 1.0;
 			};
@@ -672,7 +660,6 @@
 		A94FDCE32AFC4A86008026CE /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -687,7 +674,6 @@
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				TEST_TARGET_NAME = TestApp;
 				XROS_DEPLOYMENT_TARGET = 1.0;
@@ -732,7 +718,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		2F027C9929D6C91D00234098 /* XCRemoteSwiftPackageReference "XCTestExtensions" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions";
+			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
@@ -762,6 +748,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A969240D2A9A198800E2128B /* XCRemoteSwiftPackageReference "swift-argument-parser" */;
 			productName = ArgumentParser;
+		};
+		A994264A2CD25C50002F8BD5 /* XCTSpeziAccount */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = XCTSpeziAccount;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1610"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# Make AccountConfiguration non-generic, introduce XCTSpeziAccount

## :recycle: Current situation & Problem
This PR introduces some final adjustments for the SpeziAccount 2.0 release. Most importantly, it removes the generic constraint for the `AccountConfiguration` allowing to more easily write code that is agnostic to the account service implementation.
Secondly, we introduce the `XCTSpeziAccount` target, to make it easier to implement UI test with SpeziAccount UI components.


## :gear: Release Notes 
* Make `AccountConfiguration` non-generic
* Introduce `XCTSpeziAccount` target.

## :books: Documentation
Additional documentation target was provided.

## :white_check_mark: Testing
Existing unit and UI tests are used.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
