### PR TITLE
Make sure to only pass complete account details to the account setup complete closure

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,15 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    uses: StanfordSpezi/.github/.github/workflows/swiftlint.yml@v2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: SwiftLint
+        uses: stanfordbdhg/action-swiftlint@fix/use-latest-version
+        with:
+          args: --strict
   markdown_link_check:
     name: Markdown Link Check
     uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,15 +18,7 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/reuse.yml@v2
   swiftlint:
     name: SwiftLint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: SwiftLint
-        uses: stanfordbdhg/action-swiftlint@fix/use-latest-version
-        with:
-          args: --strict
+    uses: StanfordSpezi/.github/.github/workflows/swiftlint.yml@v2
   markdown_link_check:
     name: Markdown Link Check
     uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-prerelease-2024-08-14"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Sources/SpeziAccount/AccountConfiguration.swift
+++ b/Sources/SpeziAccount/AccountConfiguration.swift
@@ -107,9 +107,9 @@ public final class AccountConfiguration {
     ///   - configuration: The user-defined configuration of account values that all user accounts need to support.
     ///   - activeDetails: The  account details you want to simulate.
     @_spi(TestingSupport)
-    public convenience init<Service: AccountService>( // swiftlint:disable:this function_default_parameter_at_end
+    public convenience init<Service: AccountService>(
         service: Service,
-        configuration: AccountValueConfiguration = .default,
+        configuration: AccountValueConfiguration = .default, // swiftlint:disable:this function_default_parameter_at_end
         activeDetails: AccountDetails
     ) {
         self.init(accountService: service, configuration: configuration, defaultActiveDetails: activeDetails)
@@ -123,18 +123,18 @@ public final class AccountConfiguration {
     ///   - configuration: The user-defined configuration of account values that all user accounts need to support.
     ///   - activeDetails: The  account details you want to simulate.
     @_spi(TestingSupport)
-    public convenience init<Service: AccountService, Storage: AccountStorageProvider>( // swiftlint:disable:this function_default_parameter_at_end
+    public convenience init<Service: AccountService, Storage: AccountStorageProvider>(
         service: Service,
         storageProvider: Storage,
-        configuration: AccountValueConfiguration = .default,
+        configuration: AccountValueConfiguration = .default, // swiftlint:disable:this function_default_parameter_at_end
         activeDetails: AccountDetails
     ) {
         self.init(accountService: service, storageProvider: storageProvider, configuration: configuration, defaultActiveDetails: activeDetails)
     }
 
-    init<Service: AccountService>( // swiftlint:disable:this function_default_parameter_at_end
+    init<Service: AccountService>(
         accountService: Service,
-        storageProvider: (any AccountStorageProvider)? = nil,
+        storageProvider: (any AccountStorageProvider)? = nil, // swiftlint:disable:this function_default_parameter_at_end
         configuration: AccountValueConfiguration,
         defaultActiveDetails: AccountDetails? = nil
     ) {

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -92,7 +92,7 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                 guard case .presentingSignup = setupState,
                       let details = account.details,
                       !details.isAnonymous,
-                      !details.isIncomplete // make sure all details are loaded from the storage provider
+                      !details.isIncomplete // make sure all details are loaded from the storage provider 
                 else {
                     return
                 }

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -88,10 +88,11 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                     .frame(maxWidth: .infinity)
             }
         }
-            .onChange(of: [account.signedIn, account.details?.isAnonymous]) {
+            .onChange(of: [account.signedIn, account.details?.isAnonymous, account.details?.isIncomplete]) {
                 guard case .presentingSignup = setupState,
                       let details = account.details,
-                      !details.isAnonymous else {
+                      !details.isAnonymous,
+                      !details.isIncomplete else {
                     return
                 }
 

--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -92,7 +92,8 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                 guard case .presentingSignup = setupState,
                       let details = account.details,
                       !details.isAnonymous,
-                      !details.isIncomplete else {
+                      !details.isIncomplete // make sure all details are loaded from the storage provider
+                else {
                     return
                 }
 

--- a/Sources/SpeziAccount/AccountStorageProvider.swift
+++ b/Sources/SpeziAccount/AccountStorageProvider.swift
@@ -34,6 +34,7 @@ public protocol AccountStorageProvider: Module {
     ///
     /// - Important: This method call must return immediately. Use `await` suspension only be for synchronization.
     ///     Return `nil` if you couldn't immediately retrieve the externally stored account details.
+    ///     If there is no data stored externally, you need to return an empty ``AccountDetails`` value.
     ///
     /// - Parameters:
     ///   - accountId: The primary identifier for stored record.

--- a/Sources/SpeziAccount/AccountValue/Keys/AccountDetailsFlags.swift
+++ b/Sources/SpeziAccount/AccountValue/Keys/AccountDetailsFlags.swift
@@ -9,7 +9,7 @@
 import SpeziFoundation
 
 
-private struct AccountDetailsFlags: OptionSet, Sendable {
+struct AccountDetailsFlags: OptionSet, Sendable {
     let rawValue: UInt16
 
     init(rawValue: UInt16) {
@@ -34,7 +34,7 @@ extension AccountDetails {
         static let defaultValue: AccountDetailsFlags = []
     }
 
-    fileprivate var flags: AccountDetailsFlags {
+    var flags: AccountDetailsFlags {
         get {
             self[AccountDetailsFlagsKey.self]
         }

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -366,7 +366,7 @@ public final class InMemoryAccountService: AccountService {
         if !unsupportedKeys.isEmpty {
             let externalStorage = externalStorage
             let externallyStored = await externalStorage.retrieveExternalStorage(for: user.accountId.uuidString, unsupportedKeys)
-            details.add(contentsOf: externallyStored)
+            details.add(contentsOf: externallyStored) // TODO: we do not allow to overwrite flags here!
         }
 
         account.supplyUserDetails(details)

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -459,8 +459,8 @@ extension InMemoryAccountService {
         var genderIdentity: GenderIdentity?
         var dateOfBirth: Date?
 
-        init( // swiftlint:disable:this function_default_parameter_at_end
-            accountId: UUID = UUID(),
+        init(
+            accountId: UUID = UUID(), // swiftlint:disable:this function_default_parameter_at_end
             userId: String?,
             password: String?,
             name: PersonNameComponents? = nil,

--- a/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountService.swift
@@ -366,7 +366,7 @@ public final class InMemoryAccountService: AccountService {
         if !unsupportedKeys.isEmpty {
             let externalStorage = externalStorage
             let externallyStored = await externalStorage.retrieveExternalStorage(for: user.accountId.uuidString, unsupportedKeys)
-            details.add(contentsOf: externallyStored) // TODO: we do not allow to overwrite flags here!
+            details.add(contentsOf: externallyStored)
         }
 
         account.supplyUserDetails(details)

--- a/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
@@ -25,15 +25,15 @@ public actor InMemoryAccountStorageProvider: AccountStorageProvider {
     public func load(_ accountId: String, _ keys: [any AccountKey.Type]) -> AccountDetails? {
         guard let details = cache[accountId] else {
             guard records[accountId] != nil else {
-                return nil
+                return AccountDetails() // no data present
             }
 
             // simulate loading from external storage
             Task {
                 try await Task.sleep(for: .seconds(1))
-                guard let details = records[accountId] else {
-                    return
-                }
+
+                let details = records[accountId] ?? AccountDetails()
+
                 cache[accountId] = details
                 storage.notifyAboutUpdatedDetails(for: accountId, details)
             }

--- a/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/AccountServiceButton.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/AccountServiceButton.swift
@@ -36,9 +36,9 @@ public struct AccountServiceButton<Label: View>: View {
         self.init(titleKey, systemImage: systemImage, state: .constant(.idle), action: action)
     }
 
-    public init( // swiftlint:disable:this function_default_parameter_at_end
+    public init(
         _ titleKey: LocalizedStringResource,
-        systemImage: String = "person.crop.square",
+        systemImage: String = "person.crop.square", // swiftlint:disable:this function_default_parameter_at_end
         state: Binding<ViewState>,
         action: @escaping @MainActor  () async throws -> Void
     ) where Label == SwiftUI.Label<Text, Image> {

--- a/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/SignInWithAppleButton.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/SetupProvider/SignInWithAppleButton.swift
@@ -114,8 +114,8 @@ public struct SignInWithAppleButton: View {
     ///   - state: A view state binding that is used to set the error state if the `onCompletion` handler returns an error.
     ///   - onRequest: The authorization request for an Apple ID.
     ///   - onCompletion: The completion handler that the system calls when the sign-in completes.
-    public init( // swiftlint:disable:this function_default_parameter_at_end
-        _ label: AuthenticationServices.SignInWithAppleButton.Label? = nil,
+    public init(
+        _ label: AuthenticationServices.SignInWithAppleButton.Label? = nil, // swiftlint:disable:this function_default_parameter_at_end
         state: Binding<ViewState>,
         onRequest: @escaping (ASAuthorizationAppleIDRequest) -> Void,
         onCompletion: @escaping ((Result<ASAuthorization, any Error>) async throws -> Void)

--- a/Sources/SpeziAccountMacros/SpeziAccountDiagnostic.swift
+++ b/Sources/SpeziAccountMacros/SpeziAccountDiagnostic.swift
@@ -35,10 +35,10 @@ struct SpeziAccountDiagnostic: DiagnosticMessage {
 
 
 extension Diagnostic {
-    init<S: SyntaxProtocol>( // swiftlint:disable:this function_default_parameter_at_end
+    init<S: SyntaxProtocol>(
         syntax: S,
         message: String,
-        domain: String = "SpeziAccount",
+        domain: String = "SpeziAccount", // swiftlint:disable:this function_default_parameter_at_end
         id: SpeziAccountDiagnostic.ID,
         severity: SwiftDiagnostics.DiagnosticSeverity = .error
     ) {
@@ -48,10 +48,10 @@ extension Diagnostic {
 
 
 extension DiagnosticsError {
-    init<S: SyntaxProtocol>(  // swiftlint:disable:this function_default_parameter_at_end
+    init<S: SyntaxProtocol>(
         syntax: S,
         message: String,
-        domain: String = "SpeziAccount",
+        domain: String = "SpeziAccount", // swiftlint:disable:this function_default_parameter_at_end
         id: SpeziAccountDiagnostic.ID,
         severity: SwiftDiagnostics.DiagnosticSeverity = .error
     ) {

--- a/Tests/UITests/TestApp/Features.swift
+++ b/Tests/UITests/TestApp/Features.swift
@@ -47,6 +47,9 @@ struct Features: ParsableArguments {
 
     @Flag(help: "Set no name if default credentials are used")
     var noName = false
+
+    @Flag(help: "Include biography in default details")
+    var includeInvitationCode = false
 }
 
 

--- a/Tests/UITests/TestApp/Utils/AccountDetails+Default.swift
+++ b/Tests/UITests/TestApp/Utils/AccountDetails+Default.swift
@@ -18,12 +18,18 @@ extension AccountDetails {
         .day(.twoDigits)
 
     static var defaultDetails: AccountDetails {
+        let date: Date
+        do {
+            date = try Date("09.03.1824", strategy: dateStyle)
+        } catch {
+            preconditionFailure("Failed to parse date: \(error)")
+        }
         var details = AccountDetails()
         details.userId = "lelandstanford@stanford.edu"
         details.password = "StanfordRocks123!"
         details.name = PersonNameComponents(givenName: "Leland", familyName: "Stanford")
         details.genderIdentity = .male
-        details.dateOfBirth = try? Date("09.03.1824", strategy: dateStyle)
+        details.dateOfBirth = date
         return details
     }
 }

--- a/Tests/UITests/TestAppUITests/AccountSetupTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountSetupTests.swift
@@ -525,6 +525,29 @@ final class AccountSetupTests: XCTestCase { // swiftlint:disable:this type_body_
     }
 
     @MainActor
+    func testLoginWithAdditionalStorage() throws {
+        // Ensure AccountSetup properly handles the `incomplete` flag
+        // https://github.com/StanfordSpezi/SpeziAccount/pull/79
+
+        let app = XCUIApplication()
+        app.launch(config: .default, credentials: .create, includeInvitationCode: true)
+
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Spezi Account"].exists)
+
+        app.openAccountSetup()
+
+        try app.login(email: Defaults.email, password: Defaults.password)
+
+        // make sure our incomplete error never pops up
+        XCTAssert(app.alerts["Error"].waitForNonExistence(timeout: 5.0))
+
+        // verify we are back at the start screen
+        XCTAssertTrue(app.staticTexts[Defaults.email].waitForExistence(timeout: 2.0))
+    }
+
+    @MainActor
     func testAccountRequiredModifier() throws {
         let app = XCUIApplication()
         app.launch(credentials: .createAndSignIn, accountRequired: true)

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+AccountSetup.swift
@@ -18,12 +18,12 @@ extension XCUIApplication {
         XCTAssertTrue(staticTexts["Please fill out the details below to create your new account."].waitForExistence(timeout: 3.0))
     }
 
-    func fillSignupForm( // swiftlint:disable:this function_default_parameter_at_end
+    func fillSignupForm(
         email: String,
         password: String,
         name: PersonNameComponents? = nil,
         genderIdentity: String? = nil,
-        supplyDateOfBirth: Bool = false,
+        supplyDateOfBirth: Bool = false, // swiftlint:disable:this function_default_parameter_at_end
         biography: String
     ) throws {
         try fillSignupForm(email: email, password: password, name: name, genderIdentity: genderIdentity, supplyDateOfBirth: supplyDateOfBirth)

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
@@ -37,12 +37,14 @@ extension XCUIApplication {
         credentials: DefaultCredentials? = nil,
         accountRequired: Bool = false,
         noName: Bool = false,
+        includeInvitationCode: Bool = false,
         flags: String...
     ) {
         launchArguments = ["--service-type", serviceType.rawValue, "--configuration-type", config.rawValue]
         launchArguments += credentials.map { ["--credentials", $0.rawValue] } ?? []
         launchArguments += (accountRequired ? ["--account-required-modifier"] : [])
         launchArguments += (noName ? ["--no-name"] : [])
+        launchArguments += (includeInvitationCode ? ["--include-invitation-code"] : [])
         launchArguments += flags
         launch()
     }

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
@@ -31,13 +31,13 @@ enum DefaultCredentials: String {
 
 
 extension XCUIApplication {
-    func launch( // swiftlint:disable:this function_default_parameter_at_end
+    func launch(
         serviceType: ServiceType = .mail,
         config: Config = .default,
         credentials: DefaultCredentials? = nil,
         accountRequired: Bool = false,
         noName: Bool = false,
-        includeInvitationCode: Bool = false,
+        includeInvitationCode: Bool = false, // swiftlint:disable:this function_default_parameter_at_end
         flags: String...
     ) {
         launchArguments = ["--service-type", serviceType.rawValue, "--configuration-type", config.rawValue]

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -94,7 +94,11 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "createAndSignIn"
+            argument = "create"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--include-invitation-code"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
# Make sure to only pass complete account details to the account setup complete closure

## :recycle: Current situation & Problem
The `AccountSetup` accepts a `setupComplete` closure that will get called once the setup is completed giving the parent view the opportunity to perform additional checks or navigation steps based on the outcome. While a `AccountService` always calls an `ExternalStorageProvider` before submitting account details to `Account`, they have been decoupled in v2.0.0 and an `ExternalStorageProvider` must always return immediacy from its `load` call. In scenarios where account details are not locally cached yet, an `ExternalStorageProvider` returns details that are marked as [incomplete](https://swiftpackageindex.com/stanfordspezi/speziaccount/documentation/speziaccount/accountdetails/isincomplete).
`AccountSetup` didn't check for this flag and forwarded incomplete details to the `setupComplete` closure. This PR fixes this issue and updates the behavior to only forward account details that are also marked as complete.

## :gear: Release Notes 
* Fixed an issue where `AccountSetup` would forward incomplete account details and didn't wait for an `ExternalStorageProvider` to load externally stored account details.
* Fixed an issue where `flags` wouldn't be copied between account details.

## :books: Documentation
We improved some of the documentation discoverability.

## :white_check_mark: Testing
Added UI tests to verify that the incomplete details are not passed to the `setupComplete` closure.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
