### PR TITLE
AccountOverviewForm: take `closeBehavior` into account

### DIFF
--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
@@ -76,7 +76,7 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
                         } else {
                             switch closeBehavior {
                             case .disabled:
-                                let _ = ()
+                                EmptyView()
                             case .showCloseButton:
                                 Button {
                                     dismiss()

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewForm.swift
@@ -68,16 +68,21 @@ struct AccountOverviewForm<AdditionalSections: View>: View {
                 if !isProcessing {
                     ToolbarItem(placement: .cancellationAction) {
                         if editMode?.wrappedValue.isEditing == true {
-                            Button(action: {
+                            Button {
                                 model.cancelEditAction(editMode: editMode)
-                            }) {
+                            } label: {
                                 Text("CANCEL", bundle: .module)
                             }
                         } else {
-                            Button(action: {
-                                dismiss()
-                            }) {
-                                Text("CLOSE", bundle: .module)
+                            switch closeBehavior {
+                            case .disabled:
+                                let _ = ()
+                            case .showCloseButton:
+                                Button {
+                                    dismiss()
+                                } label: {
+                                    Text("CLOSE", bundle: .module)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# AccountOverviewForm: take `closeBehavior` into account

## :recycle: Current situation & Problem
`AccountOverview` allows specifying a `closeBehavior` value, which is documented as controlling whether a "Close" button is shown as part of the view.
However, this value is currently ignored, and the close button is always shown.

## :gear: Release Notes 
- `AccountOverview`: fix `closeBehavior` not having any effect

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
