### PR TITLE
Fix Sendable-related Build Errors

### DIFF
--- a/Sources/SpeziAccount/AccountSetup.swift
+++ b/Sources/SpeziAccount/AccountSetup.swift
@@ -160,7 +160,9 @@ public struct AccountSetup<Header: View, Continue: View>: View {
                 .frame(maxWidth: ViewSizing.maxFrameWidth) // landscape optimizations
                 .dynamicTypeSize(.medium ... .xxxLarge) // ui doesn't make sense on size larger than .xxxLarge
                 .receiveSignupProviderCompliance { compliance in
-                    self.compliance = compliance
+                    Task {@MainActor in
+                        self.compliance = compliance
+                    }
                 }
         }
     }

--- a/Sources/SpeziAccount/Environment/SignupProviderCompliance.swift
+++ b/Sources/SpeziAccount/Environment/SignupProviderCompliance.swift
@@ -147,7 +147,7 @@ extension View {
         preference(key: SignupProviderComplianceKey.self, value: compliance.map { .init($0) })
     }
 
-    func receiveSignupProviderCompliance(receive action: @escaping (SignupProviderCompliance?) -> Void) -> some View {
+    func receiveSignupProviderCompliance(receive action: @escaping @Sendable (SignupProviderCompliance?) -> Void) -> some View {
         onPreferenceChange(SignupProviderComplianceKey.self) { compliance in
             action(compliance?.compliance)
         }

--- a/Sources/SpeziAccount/Views/DataEntry/DateOfBirthPicker.swift
+++ b/Sources/SpeziAccount/Views/DataEntry/DateOfBirthPicker.swift
@@ -99,7 +99,9 @@ struct DateOfBirthPicker: View {
                 }
             }
             .onPreferenceChange(DynamicLayout.self) { value in
-                layout = value
+                Task { @MainActor in
+                    layout = value
+                }
             }
     }
 


### PR DESCRIPTION
# Fix Sendable-related Build Errors

## :recycle: Current situation & Problem
After addressing , `SpeziAccount` wasn't building for me with the following errors/warnings:
1. Error
```
SpeziAccount/Views/DataEntry/DateOfBirthPicker.swift:102:17
    main actor-isolated property 'layout' can not be mutated from a Sendable closure
                    layout = value
                    ^
```
2. Error:
```
  SpeziAccount/Sources/SpeziAccount/AccountSetup.swift:163:26
    main actor-isolated property 'compliance' can not be mutated from a Sendable closure
                        self.compliance = compliance
                             ^

```
4. Warning:
```
SpeziAccount/Sources/SpeziAccount/Environment/SignupProviderCompliance.swift:152:13
    capture of 'action' with non-sendable type '(SignupProviderCompliance?) -> Void' in a `@Sendable` closure
                action(compliance?.compliance)
                ^
```

## :gear: Release Notes 
* Fix the three build errors/warnings I was receiving.


## :books: Documentation
No new features were introduced that require documentation.


## :white_check_mark: Testing
* Building `SpeziAccount` is now error and warning-free for me.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

What do you think?