### PR TITLE
Move FormHeader to SpeziViews as ListHeader

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.3"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.10.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,6 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.3"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.10.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),

--- a/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
+++ b/Sources/SpeziAccount/Views/AccountSetup/FollowUpInfoSheet.swift
@@ -15,7 +15,7 @@ import SwiftUI
 
 struct FollowUpInfoFormHeader: View {
     var body: some View {
-        FormHeader {
+        ListHeader {
             Image(systemName: "person.crop.rectangle.badge.plus") // swiftlint:disable:this accessibility_label_for_image
         } title: {
             Text("FOLLOW_UP_INFORMATION_TITLE", bundle: .module)

--- a/Sources/SpeziAccount/Views/AccountSummaryBox.swift
+++ b/Sources/SpeziAccount/Views/AccountSummaryBox.swift
@@ -7,6 +7,7 @@
 //
 
 import SpeziPersonalInfo
+import SpeziViews
 import SwiftUI
 
 
@@ -15,7 +16,7 @@ struct AccountSummaryBox: View {
     private let model: AccountDisplayModel
 
     var body: some View {
-        FormHeader {
+        ListHeader {
             if let profileViewName = model.profileViewName {
                 UserProfileView(name: profileViewName)
                     .frame(height: 80)

--- a/Sources/SpeziAccount/Views/SignupFormHeader.swift
+++ b/Sources/SpeziAccount/Views/SignupFormHeader.swift
@@ -6,50 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SpeziViews
 import SwiftUI
-
-
-struct FormHeader<Image: View, Title: View, Instructions: View>: View {
-    private let image: Image
-    private let title: Title
-    private let instructions: Instructions
-
-
-    var body: some View {
-        VStack {
-            VStack {
-                image
-                    .foregroundColor(.accentColor)
-                    .symbolRenderingMode(.multicolor)
-                    .font(.custom("XXL", size: 50, relativeTo: .title))
-                    .accessibilityHidden(true)
-                title
-                    .accessibilityAddTraits(.isHeader)
-                    .font(.title)
-                    .bold()
-                    .padding(.bottom, 4)
-            }
-                .accessibilityElement(children: .combine)
-            instructions
-                .padding([.leading, .trailing], 25)
-        }
-            .multilineTextAlignment(.center)
-            .frame(maxWidth: .infinity)
-    }
-
-    init(@ViewBuilder image: () -> Image, @ViewBuilder title: () -> Title, @ViewBuilder instructions: () -> Instructions) {
-        self.image = image()
-        self.title = title()
-        self.instructions = instructions()
-    }
-}
 
 
 public struct SignupFormHeader: View {
     public var body: some View {
-        FormHeader {
-            Image(systemName: "person.fill.badge.plus") // swiftlint:disable:this accessibility_label_for_image
-        } title: {
+        ListHeader(systemImage: "person.fill.badge.plus") {
             Text("UP_SIGNUP_HEADER", bundle: .module)
         } instructions: {
             Text("UP_SIGNUP_INSTRUCTIONS", bundle: .module)


### PR DESCRIPTION
# Move FormHeader to SpeziViews as ListHeader


## :gear: Release Notes 
* Move FormHeader to SpeziViews as ListHeader to reuse this view across other Spezi libraries.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
