### PR TITLE
relax the swift-syntax requirement from `>=601.0.1` to `>=601.0.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.2"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.2.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.17.0")
     ] + swiftLintPackage(),
     targets: [


### PR DESCRIPTION
# relax the swift-syntax requirement from `>=601.0.1` to `>=601.0.0`

## :recycle: Current situation & Problem
#66 updated the swift-syntax dependency to requiring at least version 601.0.1, which is incompatible with the latest SwiftLint release, which requires exactly 601.0.0.
This isn't an issue when compiling the SpeziAccount package on its own, or using it in an app that doesn't use the SwiftLint plug in; but when using the plug in this causes the package resolution to fail.
This PR attempts to fix this.


## :gear: Release Notes
- relaxed swift-syntax requirement to restore SwiftLint compatibility


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
