### PR TITLE
Allow to specify and customize display and mutation behavior of Account Keys

### DIFF
--- a/Sources/SpeziAccount/AccountValue/AccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey.swift
@@ -56,7 +56,10 @@ public protocol AccountKey: KnowledgeSource<AccountAnchor> where Value: Sendable
     /// The ``AccountKeyCategory`` is used to group ``DataEntryView``s in views like the ``SignupForm``.
     /// Use ``AccountKeyCategory/other`` to move the ``DataEntry`` view to a unnamed group at the bottom.
     static var category: AccountKeyCategory { get }
-    
+
+    /// Options to configure the behavior of the account key.
+    ///
+    /// Refer to ``AccountKeyOptions`` for more information.
     static var options: AccountKeyOptions { get }
 
     /// The initial value that is used when supplying a new account value.

--- a/Sources/SpeziAccount/AccountValue/AccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey.swift
@@ -36,26 +36,28 @@ public protocol AccountKey: KnowledgeSource<AccountAnchor> where Value: Sendable
     /// This view is used in views like the ``AccountOverview`` to display the current value for this `AccountKey`.
     /// - Note: Refer to the <doc:Adding-new-Account-Values> article for a list of ``DataDisplayView`` that are automatically provided.
     associatedtype DataDisplay: DataDisplayView<Value>
-
+    
     /// The view that is used to enter a value for this account value.
     ///
     /// This view is used in views like the ``SignupForm`` to enter the account value.
     /// - Note: Refer to the <doc:Adding-new-Account-Values> article for a list of ``DataDisplayView`` that are automatically provided.
     associatedtype DataEntry: DataEntryView<Value>
-
+    
     /// The user-visible, localized name of the account key.
     static var name: LocalizedStringResource { get }
-
+    
     /// A string-based identifier that is meant to be stable. Used by storage modules.
     ///
     /// By default this maps to the type name.
     static var identifier: String { get }
-
+    
     /// The category of the account key.
     ///
     /// The ``AccountKeyCategory`` is used to group ``DataEntryView``s in views like the ``SignupForm``.
     /// Use ``AccountKeyCategory/other`` to move the ``DataEntry`` view to a unnamed group at the bottom.
     static var category: AccountKeyCategory { get }
+    
+    static var options: AccountKeyOptions { get }
 
     /// The initial value that is used when supplying a new account value.
     ///

--- a/Sources/SpeziAccount/AccountValue/AccountKeyCategory.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyCategory.swift
@@ -47,7 +47,7 @@ public struct AccountKeyCategory {
         self.categoryTitle = categoryTitle
     }
 
-    /// Instantiate a new ``AccountKeyCategory``.
+    /// Instantiate a new `AccountKeyCategory`.
     /// - Parameter categoryTitle: The localized section title. The key is also used a identifier for the `Identifiable` conformance.
     public init(title categoryTitle: LocalizedStringResource) {
         self.categoryTitle = categoryTitle

--- a/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
@@ -42,13 +42,13 @@ public struct _EmptyDataView: DataDisplayView, DataEntryView { // swiftlint:disa
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
-///   - options: The AccountKeyOptions.
+///   - options: The ``AccountKeyOptions`` allowing to customize display and mutation behavior.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - initial: The initial value used when entering
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this account key.
 @attached(accessor, names: named(get), named(set))
-@attached(peer, names: prefixed(__Key_)) // TODO: property docs
+@attached(peer, names: prefixed(__Key_))
 public macro AccountKey<Value, DataDisplay: DataDisplayView, DataEntry: DataEntryView>(
     id: String? = nil,
     name: LocalizedStringResource,
@@ -80,6 +80,7 @@ public macro AccountKey<Value, DataDisplay: DataDisplayView, DataEntry: DataEntr
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
+///   - options: The ``AccountKeyOptions`` allowing to customize display and mutation behavior.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this a
@@ -89,6 +90,7 @@ public macro AccountKey<Value: StringProtocol, DataDisplay: DataDisplayView, Dat
     id: String? = nil,
     name: LocalizedStringResource,
     category: AccountKeyCategory = .other,
+    options: AccountKeyOptions = .default,
     as value: Value.Type,
     displayView: DataDisplay.Type = _EmptyDataView.self,
     entryView: DataEntry.Type = _EmptyDataView.self
@@ -114,6 +116,7 @@ public macro AccountKey<Value: StringProtocol, DataDisplay: DataDisplayView, Dat
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
+///   - options: The ``AccountKeyOptions`` allowing to customize display and mutation behavior.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this a
@@ -123,6 +126,7 @@ public macro AccountKey<DataDisplay: DataDisplayView, DataEntry: DataEntryView>(
     id: String? = nil,
     name: LocalizedStringResource,
     category: AccountKeyCategory = .other,
+    options: AccountKeyOptions = .default,
     as value: Bool.Type,
     displayView: DataDisplay.Type = _EmptyDataView.self,
     entryView: DataEntry.Type = _EmptyDataView.self
@@ -148,6 +152,7 @@ public macro AccountKey<DataDisplay: DataDisplayView, DataEntry: DataEntryView>(
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
+///   - options: The ``AccountKeyOptions`` allowing to customize display and mutation behavior.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this a
@@ -157,6 +162,7 @@ public macro AccountKey<Value: AdditiveArithmetic, DataDisplay: DataDisplayView,
     id: String? = nil,
     name: LocalizedStringResource,
     category: AccountKeyCategory = .other,
+    options: AccountKeyOptions = .default,
     as value: Value.Type,
     displayView: DataDisplay.Type = _EmptyDataView.self,
     entryView: DataEntry.Type = _EmptyDataView.self
@@ -182,6 +188,7 @@ public macro AccountKey<Value: AdditiveArithmetic, DataDisplay: DataDisplayView,
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
+///   - options: The ``AccountKeyOptions`` allowing to customize display and mutation behavior.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this a
@@ -191,6 +198,7 @@ public macro AccountKey<Value: ExpressibleByArrayLiteral, DataDisplay: DataDispl
     id: String? = nil,
     name: LocalizedStringResource,
     category: AccountKeyCategory = .other,
+    options: AccountKeyOptions = .default,
     as value: Value.Type,
     displayView: DataDisplay.Type = _EmptyDataView.self,
     entryView: DataEntry.Type = _EmptyDataView.self

--- a/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
@@ -42,16 +42,18 @@ public struct _EmptyDataView: DataDisplayView, DataEntryView { // swiftlint:disa
 ///   - id: A stable, string-based identifier that is used by storage providers.
 ///   - name: The user-visible, localized name of the account key.
 ///   - category: The category the account key belongs to. It will be used to visually group similar account details together.
+///   - options: The AccountKeyOptions.
 ///   - value: The value type. This type must be equal to the type annotation of the property.
 ///   - initial: The initial value used when entering
 ///   - displayView: A customized ``DataDisplayView`` that is used to display existing values of this account key.
 ///   - entryView: A customized ``DataEntryView`` that is used to enter new or edit existing values of this account key.
 @attached(accessor, names: named(get), named(set))
-@attached(peer, names: prefixed(__Key_))
+@attached(peer, names: prefixed(__Key_)) // TODO: property docs
 public macro AccountKey<Value, DataDisplay: DataDisplayView, DataEntry: DataEntryView>(
     id: String? = nil,
     name: LocalizedStringResource,
     category: AccountKeyCategory = .other,
+    options: AccountKeyOptions = .default,
     as value: Value.Type,
     initial: InitialValue<Value>,
     displayView: DataDisplay.Type = _EmptyDataView.self,

--- a/Sources/SpeziAccount/AccountValue/AccountKeyOptions.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyOptions.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+public struct AccountKeyOptions: OptionSet { // TODO: docs!
+    public let rawValue: UInt64
+
+    public init(rawValue: UInt64) {
+        self.rawValue = rawValue
+    }
+}
+
+
+extension AccountKeyOptions: Hashable, Sendable, Codable {}
+
+
+extension AccountKeyOptions {
+    public static let read = AccountKeyOptions(rawValue: 1 << 0)
+    public static let write = AccountKeyOptions(rawValue: 1 << 1)
+
+    public static let `default`: AccountKeyOptions = [.read, .write]
+}

--- a/Sources/SpeziAccount/AccountValue/AccountKeyOptions.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyOptions.swift
@@ -7,7 +7,8 @@
 //
 
 
-public struct AccountKeyOptions: OptionSet { // TODO: docs!
+/// Options associated with an Account Key.
+public struct AccountKeyOptions: OptionSet {
     public let rawValue: UInt64
 
     public init(rawValue: UInt64) {
@@ -20,8 +21,23 @@ extension AccountKeyOptions: Hashable, Sendable, Codable {}
 
 
 extension AccountKeyOptions {
-    public static let read = AccountKeyOptions(rawValue: 1 << 0)
-    public static let write = AccountKeyOptions(rawValue: 1 << 1)
+    /// The account key supports to be displayed to the user.
+    ///
+    /// An Account Key always implicitly supports read access. Therefore, when `display` is supported, a ``DataDisplayView`` is required to be specified (or relying on a default implementation fo
+    /// the given type).
+    /// If ``mutable`` option is set as well, a ``DataEntryView`` is likewise required to be specified.
+    public static let display = AccountKeyOptions(rawValue: 1 << 0)
+    /// The account key supports mutation.
+    ///
+    /// This option marks the account key to support user-initiated (or think of as client-side initiated) mutation.
+    /// Having this option not set does not prevent server-side permutation (e.g., as a side effect of some request).
+    /// Instead it makes it explicit that the user (or rather client-side code) is allowed to mutate the value themselves (assuming some authorization checks).
+    ///
+    /// If the the ``display`` option is set, you must supply a ``DataEntryView`` to allow permutation from UI.
+    public static let mutable = AccountKeyOptions(rawValue: 1 << 1)
 
-    public static let `default`: AccountKeyOptions = [.read, .write]
+    /// The default configuration for an Account Key.
+    ///
+    /// By default, an Account Key is ``display``ed and ``mutable``.
+    public static let `default`: AccountKeyOptions = [.display, .mutable]
 }

--- a/Sources/SpeziAccount/AccountValue/Configuration/AccountOperationError.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/AccountOperationError.swift
@@ -25,6 +25,8 @@ public enum AccountOperationError: LocalizedError {
     ///
     /// The stable ``AccountDetails/accountId`` was tried to be modified.
     case accountIdChanged
+    /// Tried to modify account details that are not supported to be modified from the client side.
+    case mutatingNonMutableAccountKeys(_ keyNames: [String])
 
 
     public var errorDescription: String? {
@@ -43,22 +45,31 @@ public enum AccountOperationError: LocalizedError {
     private var errorDescriptionValue: String.LocalizationValue {
         switch self {
         case .missingAccountValue:
-            return "ACCOUNT_ERROR_VALUES_MISSING_VALUE_DESCRIPTION"
+            "ACCOUNT_ERROR_VALUES_MISSING_VALUE_DESCRIPTION"
         case .accountIdChanged:
-            return "ACCOUNT_ERROR_ACCOUNT_ID_CHANGED_DESCRIPTION"
+            "ACCOUNT_ERROR_ACCOUNT_ID_CHANGED_DESCRIPTION"
+        case .mutatingNonMutableAccountKeys:
+            "Invalid Modification"
         }
     }
 
     private var failureReasonValue: String.LocalizationValue {
         switch self {
         case let .missingAccountValue(keyName):
-            return "ACCOUNT_ERROR_VALUES_MISSING_VALUE_REASON \(keyName.joined(separator: ", "))"
+            "ACCOUNT_ERROR_VALUES_MISSING_VALUE_REASON \(keyName.joined(separator: ", "))"
         case .accountIdChanged:
-            return "ACCOUNT_ERROR_ACCOUNT_ID_CHANGED_REASON"
+            "ACCOUNT_ERROR_ACCOUNT_ID_CHANGED_REASON"
+        case let .mutatingNonMutableAccountKeys(keyName):
+            "The following account values are not mutable: \(keyName.joined(separator: ", "))."
         }
     }
 
     private var recoverySuggestionValue: String.LocalizationValue {
-        "ACCOUNT_ERROR_RECOVERY"
+        switch self {
+        case .missingAccountValue, .accountIdChanged:
+            "ACCOUNT_ERROR_RECOVERY"
+        case .mutatingNonMutableAccountKeys:
+            "Please raise an issue with the App developer."
+        }
     }
 }

--- a/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
@@ -58,7 +58,9 @@ public struct AccountValueConfiguration {
         }
     }
 
-    func allCategorizedForDisplay(filteredBy filter: Set<AccountKeyRequirement>? = nil) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
+    func allCategorizedForDisplay(
+        filteredBy filter: Set<AccountKeyRequirement>? = nil
+    ) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
         // swiftlint:disable:previous discouraged_optional_collection
         let requiredOptions: AccountKeyOptions = if let filter, !filter.isDisjoint(with: [.required, .collected]) {
             // if we are filtering for requirements that do not allow for `mutable` to be missing, we need to enforce and filter for that

--- a/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
@@ -59,9 +59,8 @@ public struct AccountValueConfiguration {
     }
 
     func allCategorizedForDisplay(
-        filteredBy filter: Set<AccountKeyRequirement>? = nil
+        filteredBy filter: Set<AccountKeyRequirement>? = nil // swiftlint:disable:this discouraged_optional_collection
     ) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
-        // swiftlint:disable:previous discouraged_optional_collection
         let requiredOptions: AccountKeyOptions = if let filter, !filter.isDisjoint(with: [.required, .collected]) {
             // if we are filtering for requirements that do not allow for `mutable` to be missing, we need to enforce and filter for that
             [.display, .mutable]

--- a/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
@@ -58,20 +58,28 @@ public struct AccountValueConfiguration {
         }
     }
 
-    func allCategorized(filteredBy filter: [AccountKeyRequirement]? = nil) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
+    func allCategorizedForDisplay(filteredBy filter: Set<AccountKeyRequirement>? = nil) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
         // swiftlint:disable:previous discouraged_optional_collection
-        if let filter {
-            return self.reduce(into: [:]) { result, configuration in
-                guard filter.contains(configuration.requirement) else {
-                    return
-                }
+        let requiredOptions: AccountKeyOptions = if let filter, !filter.isDisjoint(with: [.required, .collected]) {
+            // if we are filtering for requirements that do not allow for `mutable` to be missing, we need to enforce and filter for that
+            [.display, .mutable]
+        } else {
+            .display
+        }
 
-                result[configuration.key.category, default: []] += [configuration.key]
+        let collection: some Collection<any AccountKeyConfiguration> = if let filter {
+            self.lazy.filter { configuration in
+                configuration.key.options.contains(requiredOptions)
+                    && filter.contains(configuration.requirement)
             }
         } else {
-            return self.reduce(into: [:]) { result, configuration in
-                result[configuration.key.category, default: []] += [configuration.key]
+            self.lazy.filter { configuration in
+                configuration.key.options.contains(requiredOptions)
             }
+        }
+
+        return collection.reduce(into: [:]) { result, configuration in
+            result[configuration.key.category, default: []] += [configuration.key]
         }
     }
 
@@ -84,7 +92,8 @@ public struct AccountValueConfiguration {
             .union(Set(ignoring.map { ObjectIdentifier($0) }))
 
         let missingKeys = filter { entry in
-            entry.key.category != .credentials // generally, don't collect credentials!
+            entry.key.options.contains([.display, .mutable]) // do not consider details that are not capable of being displayed or mutated
+                && entry.key.category != .credentials // generally, don't collect credentials!
                 && (entry.requirement == .required || entry.requirement == .collected) // not interested in supported keys
                 && !keysPresent.contains(ObjectIdentifier(entry.key)) // missing on the current details
         }

--- a/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/AccountValueConfiguration.swift
@@ -58,16 +58,10 @@ public struct AccountValueConfiguration {
         }
     }
 
-    func allCategorizedForDisplay(
-        filteredBy filter: Set<AccountKeyRequirement>? = nil // swiftlint:disable:this discouraged_optional_collection
+    func allCategorized(
+        filteredBy filter: Set<AccountKeyRequirement>? = nil, // swiftlint:disable:this discouraged_optional_collection
+        requiredOptions: AccountKeyOptions = .display
     ) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
-        let requiredOptions: AccountKeyOptions = if let filter, !filter.isDisjoint(with: [.required, .collected]) {
-            // if we are filtering for requirements that do not allow for `mutable` to be missing, we need to enforce and filter for that
-            [.display, .mutable]
-        } else {
-            .display
-        }
-
         let collection: some Collection<any AccountKeyConfiguration> = if let filter {
             self.lazy.filter { configuration in
                 configuration.key.options.contains(requiredOptions)

--- a/Sources/SpeziAccount/AccountValue/Configuration/ConfiguredAccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/ConfiguredAccountKey.swift
@@ -35,59 +35,129 @@ public struct ConfiguredAccountKey {
 
 
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/required``.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
     /// - Returns: Returns the ``AccountKey`` configuration.
-    public static func requires<Key: AccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .required))
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
+    public static func requires<Key: AccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        precondition(
+            Key.options.contains([.display, .mutable]),
+            "AccountKey can only be required if its mutable and able to be displayed. Make sure that `mutable` and `display` options are set.",
+            file: file,
+            line: line
+        )
+        return .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .required))
     }
 
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/collected``.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @_disfavoredOverload
-    public static func collects<Key: AccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .collected))
+    public static func collects<Key: AccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        precondition(
+            Key.options.contains([.display, .mutable]),
+            "AccountKey can only be collected if its mutable and able to be displayed. Make sure that `mutable` and `display` options are set.",
+            file: file,
+            line: line
+        )
+        return .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .collected))
     }
 
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/supported``.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @_disfavoredOverload
-    public static func supports<Key: AccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .supported))
+    public static func supports<Key: AccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        precondition(
+            Key.options.contains([.display, .mutable]),
+            "AccountKey can only be supported if its able to be displayed. Make sure that the `display` option is set.",
+            file: file,
+            line: line
+        )
+        return .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .supported))
     }
     
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/manual``.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @_disfavoredOverload
-    public static func manual<Key: AccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .manual))
+    public static func manual<Key: AccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        // just making sure we are consistent
+        _ = file
+        _ = line
+        return .init(configuration: AccountKeyConfigurationImpl(keyPath, requirement: .manual))
     }
 
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/required`` as ``RequiredAccountKey`` can only be configured as required.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @available(*, deprecated, renamed: "requires", message: "A 'RequiredAccountKey' must always be supplied as required using requires(_:)")
-    public static func collects<Key: RequiredAccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
+    public static func collects<Key: RequiredAccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
         // sadly we can't make this a compiler error. using `unavailable` makes it unavailable as an overload completely.
-        requires(keyPath)
+        requires(keyPath, file: file, line: line)
     }
 
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/required`` as ``RequiredAccountKey`` can only be configured as required.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @available(*, deprecated, renamed: "requires", message: "A 'RequiredAccountKey' must always be supplied as required using requires(_:)")
-    public static func supports<Key: RequiredAccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        requires(keyPath)
+    public static func supports<Key: RequiredAccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        requires(keyPath, file: file, line: line)
     }
     
     /// Configure an ``AccountKey`` as ``AccountKeyRequirement/required`` as ``RequiredAccountKey`` can only be configured as required.
-    /// - Parameter keyPath: The `KeyPath` referencing the ``AccountKey``.
+    /// - Parameters:
+    ///   - keyPath: The `KeyPath` referencing the ``AccountKey``.
+    ///   - file: The file where the requirement is defined.
+    ///   - line: The line in which the requirement is defined.
     /// - Returns: Returns the ``AccountKey`` configuration.
     @available(*, deprecated, renamed: "requires", message: "A 'RequiredAccountKey' must always be supplied as required using requires(_:)")
-    public static func manual<Key: RequiredAccountKey>(_ keyPath: KeyPath<AccountKeys, Key.Type>) -> ConfiguredAccountKey {
-        requires(keyPath)
+    public static func manual<Key: RequiredAccountKey>(
+        _ keyPath: KeyPath<AccountKeys, Key.Type>,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) -> ConfiguredAccountKey {
+        requires(keyPath, file: file, line: line)
     }
 }
 

--- a/Sources/SpeziAccount/AccountValue/Configuration/ConfiguredAccountKey.swift
+++ b/Sources/SpeziAccount/AccountValue/Configuration/ConfiguredAccountKey.swift
@@ -88,7 +88,7 @@ public struct ConfiguredAccountKey {
         line: UInt = #line
     ) -> ConfiguredAccountKey {
         precondition(
-            Key.options.contains([.display, .mutable]),
+            Key.options.contains([.display]),
             "AccountKey can only be supported if its able to be displayed. Make sure that the `display` option is set.",
             file: file,
             line: line

--- a/Sources/SpeziAccount/ExternalAccountStorage.swift
+++ b/Sources/SpeziAccount/ExternalAccountStorage.swift
@@ -105,6 +105,12 @@ public final class ExternalAccountStorage {
             preconditionFailure("An External AccountStorageProvider was assumed to be present. However no provider was configured.")
         }
 
+        // just a save-guard and helper for debugging
+        let unsupported = details.keys.filter { !$0.options.contains(.mutable) }
+        if !unsupported.isEmpty {
+            throw AccountOperationError.mutatingNonMutableAccountKeys(unsupported.map { $0.identifier })
+        }
+
         try await storageProvider.store(accountId, details)
     }
 
@@ -157,6 +163,13 @@ public final class ExternalAccountStorage {
     public func updateExternalStorage(with modifications: AccountModifications, for accountId: String) async throws {
         guard let storageProvider else {
             preconditionFailure("An External AccountStorageProvider was assumed to be present. However no provider was configured.")
+        }
+
+        // just a save-guard and helper for debugging
+        let unsupported = modifications.modifiedDetails.keys.filter { !$0.options.contains(.mutable) }
+            + modifications.removedAccountKeys.filter { !$0.options.contains(.mutable) }
+        if !unsupported.isEmpty {
+            throw AccountOperationError.mutatingNonMutableAccountKeys(unsupported.map { $0.identifier })
         }
 
         try await storageProvider.store(accountId, modifications)

--- a/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
@@ -22,6 +22,22 @@ public actor InMemoryAccountStorageProvider: AccountStorageProvider {
 
     public init() {}
 
+    /// Used in testing to simulate a remote update and inject stored values into the storage provider
+    ///
+    /// This will case the account service to be notified about updated details.
+    /// - Parameters:
+    ///   - accountId: The account id.
+    ///   - modifications: The modifications to apply.
+    public func simulateRemoteUpdate(for accountId: String, _ modifications: AccountModifications) {
+        self.store(accountId, modifications)
+
+        guard let details = records[accountId] else {
+            fatalError("Inconsistent state!")
+        }
+
+        storage.notifyAboutUpdatedDetails(for: accountId, details)
+    }
+
     public func load(_ accountId: String, _ keys: [any AccountKey.Type]) -> AccountDetails? {
         guard let details = cache[accountId] else {
             guard records[accountId] != nil else {

--- a/Sources/SpeziAccount/Mock/MockBoolKey.swift
+++ b/Sources/SpeziAccount/Mock/MockBoolKey.swift
@@ -16,4 +16,5 @@ public struct MockBoolKey: AccountKey {
     public static let name: LocalizedStringResource = "Toggle"
     public static let identifier = "mockBool"
     public static let category: AccountKeyCategory = .other
+    public static let options: AccountKeyOptions = .default
 }

--- a/Sources/SpeziAccount/Mock/MockDoubleKey.swift
+++ b/Sources/SpeziAccount/Mock/MockDoubleKey.swift
@@ -16,4 +16,5 @@ public struct MockDoubleKey: AccountKey {
     public static let name: LocalizedStringResource = "Double Key"
     public static let identifier = "mockDouble"
     public static let category: AccountKeyCategory = .other
+    public static let options: AccountKeyOptions = .default
 }

--- a/Sources/SpeziAccount/Mock/MockNumericKey.swift
+++ b/Sources/SpeziAccount/Mock/MockNumericKey.swift
@@ -16,4 +16,5 @@ public struct MockNumericKey: AccountKey {
     public static let name: LocalizedStringResource = "Numeric Key"
     public static let identifier = "mockNumeric"
     public static let category: AccountKeyCategory = .other
+    public static let options: AccountKeyOptions = .default
 }

--- a/Sources/SpeziAccount/Resources/Localizable.xcstrings
+++ b/Sources/SpeziAccount/Resources/Localizable.xcstrings
@@ -1131,11 +1131,27 @@
         }
       }
     },
+    "Invalid Modification" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültige Änderungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invalid Modification"
+          }
+        }
+      }
+    },
     "MISSING_ACCOUNT_DETAILS" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "**Kein Benutzerkonto gefunden.**\n\nDiese Oberfläche erfordert ein aktives Benutzerkonto.\nBitte kontaktiere die Dokumentation für die AccountSetup Oberfläche, um ein Benutzerkonto einzurichten."
           }
         },
@@ -1163,7 +1179,7 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "**Es wurden keine Account Services konfiguriert.**\n\nBitte kontaktiere die Dokumentation von SpeziAccount für mehr Informationen zur Konfiguration eines AccountServices!"
           }
         },
@@ -1301,6 +1317,18 @@
     },
     "No Account Service" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Account Service"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No Account Service"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1311,6 +1339,18 @@
     },
     "No User Account" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kein Benutzerkonto"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No User Account"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1441,6 +1481,22 @@
         }
       }
     },
+    "Please raise an issue with the App developer." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Melde dieses Problem dem App Entwickler."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please raise an issue with the App developer."
+          }
+        }
+      }
+    },
     "REMOVE_DEFAULT_ERROR" : {
       "localizations" : {
         "de" : {
@@ -1549,6 +1605,22 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inloggning & säkerhet"
+          }
+        }
+      }
+    },
+    "The following account values are not mutable: %@." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Folgenden Werte können nicht bearbeitet werden: %@."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The following account values are not mutable: %@."
           }
         }
       }

--- a/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
@@ -188,6 +188,7 @@ Still, you are required to evaluate to which extent validation has to be handled
 - ``InitialValue``
 - ``AccountKey``
 - ``RequiredAccountKey``
+- ``AccountKeyOptions``
 
 ### Displaying Account Keys
 

--- a/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
+++ b/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
@@ -46,7 +46,10 @@ class AccountOverviewFormViewModel {
 
 
     init(_ valueConfiguration: AccountValueConfiguration, _ serviceConfiguration: AccountServiceConfiguration) {
-        self.categorizedAccountKeys = valueConfiguration.allCategorizedForDisplay(filteredBy: [.required, .collected, .supported])
+        self.categorizedAccountKeys = valueConfiguration.allCategorized(
+            filteredBy: [.required, .collected, .supported],
+            requiredOptions: .display // we just manually check later if we display mutable account keys in edit mode
+        )
         self.accountServiceConfiguration = serviceConfiguration
     }
 

--- a/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
+++ b/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
@@ -46,7 +46,7 @@ class AccountOverviewFormViewModel {
 
 
     init(_ valueConfiguration: AccountValueConfiguration, _ serviceConfiguration: AccountServiceConfiguration) {
-        self.categorizedAccountKeys = valueConfiguration.allCategorized(filteredBy: [.required, .collected, .supported])
+        self.categorizedAccountKeys = valueConfiguration.allCategorizedForDisplay(filteredBy: [.required, .collected, .supported])
         self.accountServiceConfiguration = serviceConfiguration
     }
 
@@ -54,6 +54,9 @@ class AccountOverviewFormViewModel {
         self.init(account.configuration, details.accountServiceConfiguration)
     }
 
+
+    // TODO: disable them if they are in edit mode!!!
+    // TODO: throw an Localized Error if attempting to write a non-mutable account key!
 
     func accountKeys(by category: AccountKeyCategory, using details: AccountDetails) -> [any AccountKey.Type] {
         var result = categorizedAccountKeys[category, default: []]
@@ -85,7 +88,9 @@ class AccountOverviewFormViewModel {
             value.sorted(using: AccountOverviewValuesComparator(details: accountDetails, added: addedAccountKeys, removed: removedAccountKeys))
         }
     }
-
+    
+    /// The list of account keys that are **potentially** editable.
+    /// - Parameter accountDetails: The current account details.
     func editableAccountKeys(details accountDetails: AccountDetails) -> OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
         baseSortedAccountKeys(details: accountDetails).filter { category, _ in
             category != .credentials && category != .name

--- a/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
+++ b/Sources/SpeziAccount/ViewModel/AccountOverviewFormViewModel.swift
@@ -54,10 +54,6 @@ class AccountOverviewFormViewModel {
         self.init(account.configuration, details.accountServiceConfiguration)
     }
 
-
-    // TODO: disable them if they are in edit mode!!!
-    // TODO: throw an Localized Error if attempting to write a non-mutable account key!
-
     func accountKeys(by category: AccountKeyCategory, using details: AccountDetails) -> [any AccountKey.Type] {
         var result = categorizedAccountKeys[category, default: []]
             .sorted(using: AccountOverviewValuesComparator(details: details, added: addedAccountKeys, removed: removedAccountKeys))

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -22,7 +22,7 @@ struct AccountKeyOverviewRow: View {
     private var editMode
 
     var body: some View {
-        if editMode?.wrappedValue.isEditing == true {
+        if editMode?.wrappedValue.isEditing == true && accountKey.options.contains(.mutable) {
             // we place everything in the same HStack, such that animations are smooth
             let hStack = VStack {
                 if accountDetails.contains(accountKey) && !model.removedAccountKeys.contains(accountKey) {
@@ -38,7 +38,7 @@ struct AccountKeyOverviewRow: View {
                     accountKey.emptyDataEntryView()
                         .deleteDisabled(false)
                         .environment(\.accountViewType, .overview(mode: .new))
-                } else {
+                } else if accountKey.options.contains(.mutable) { // client side mutation allowed
                     Button(action: {
                         model.addAccountDetail(for: accountKey)
                     }) {
@@ -71,13 +71,13 @@ struct AccountKeyOverviewRow: View {
 
 
     @MainActor
-    func isDeleteDisabled(for key: any AccountKey.Type) -> Bool {
+    private func isDeleteDisabled(for key: any AccountKey.Type) -> Bool {
         if accountDetails.contains(key) && !model.removedAccountKeys.contains(key) {
             return account.configuration[key]?.requirement == .required
         }
 
-        // if not in the addedAccountKeys, it's a "add" button
-        return !model.addedAccountKeys.contains(key)
+        // if not in the addedAccountKeys, it's a "add" button (which we shouldn't delete)
+        return !key.options.contains(.mutable) || !model.addedAccountKeys.contains(key)
     }
 }
 

--- a/Sources/SpeziAccount/Views/SignupForm.swift
+++ b/Sources/SpeziAccount/Views/SignupForm.swift
@@ -37,7 +37,10 @@ public struct SignupForm<Header: View>: View {
     @State private var presentingCloseConfirmation = false
 
     @MainActor private var accountKeyByCategory: OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
-        var result = account.configuration.allCategorizedForDisplay(filteredBy: [.required, .collected])
+        var result = account.configuration.allCategorized(
+            filteredBy: [.required, .collected],
+            requiredOptions: [.display, .mutable] // all values provided at signup must be mutable, we already enforce this in `ConfiguredAccountKey`
+        )
 
         // do not show fields that are already present on an anonymous account
         if let details = account.details, details.isAnonymous {

--- a/Sources/SpeziAccount/Views/SignupForm.swift
+++ b/Sources/SpeziAccount/Views/SignupForm.swift
@@ -37,7 +37,7 @@ public struct SignupForm<Header: View>: View {
     @State private var presentingCloseConfirmation = false
 
     @MainActor private var accountKeyByCategory: OrderedDictionary<AccountKeyCategory, [any AccountKey.Type]> {
-        var result = account.configuration.allCategorized(filteredBy: [.required, .collected])
+        var result = account.configuration.allCategorizedForDisplay(filteredBy: [.required, .collected])
 
         // do not show fields that are already present on an anonymous account
         if let details = account.details, details.isAnonymous {

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -50,6 +50,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     static var initialValue: InitialValue<Value> {
                         .default(.preferNotToState)
                     }
+                    static let options: AccountKeyOptions = .default
                 }
             }
             """,
@@ -94,6 +95,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     static var initialValue: InitialValue<Value> {
                         .default(.preferNotToState)
                     }
+                    static let options: AccountKeyOptions = .default
                 }
             }
             """,
@@ -132,6 +134,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     public static var initialValue: InitialValue<Value> {
                         .default(.preferNotToState)
                     }
+                    public static let options: AccountKeyOptions = .default
                 }
             }
             """,
@@ -167,6 +170,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     static let name: LocalizedStringResource = "Account Id"
                     static let identifier: String = "accountId"
                     static let category: AccountKeyCategory = .other
+                    static let options: AccountKeyOptions = .default
                 }
             }
             """,
@@ -242,6 +246,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     public static var initialValue: InitialValue<Value> {
                         .default(.preferNotToState)
                     }
+                    public static let options: AccountKeyOptions = .default
                     public struct DataDisplay: DataDisplayView {
                         private let value: Value
 
@@ -309,6 +314,7 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                     static var initialValue: InitialValue<Value> {
                         .default(.preferNotToState)
                     }
+                    static let options: AccountKeyOptions = .default
                     struct DataDisplay: DataDisplayView {
                         private let value: Value
             
@@ -337,6 +343,228 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
             diagnostics: [
                 DiagnosticSpec(message: "The type name 'DataDisplay' is ambiguous. Please disambiguate or rename.", line: 7, column: 22),
                 DiagnosticSpec(message: "The type name 'DataEntry' is ambiguous. Please disambiguate or rename.", line: 8, column: 20)
+            ],
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+    }
+
+    @Test
+    func testAccountKeyOptions() {
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: .default, as: String.self, initial: .default("Hello World"))
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            
+                struct __Key_name: AccountKey {
+                    typealias Value = String
+            
+                    static let name: LocalizedStringResource = "Name"
+                    static let identifier: String = "name"
+                    static let category: AccountKeyCategory = .other
+                    static var initialValue: InitialValue<Value> {
+                        .default("Hello World")
+                    }
+                    static let options: AccountKeyOptions = .default
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: [.read, .write], as: String.self, initial: .default("Hello World"))
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            
+                struct __Key_name: AccountKey {
+                    typealias Value = String
+            
+                    static let name: LocalizedStringResource = "Name"
+                    static let identifier: String = "name"
+                    static let category: AccountKeyCategory = .other
+                    static var initialValue: InitialValue<Value> {
+                        .default("Hello World")
+                    }
+                    static let options: AccountKeyOptions = [.read, .write]
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: [.read], as: String.self, initial: .default("Hello World"))
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            
+                struct __Key_name: AccountKey {
+                    typealias Value = String
+            
+                    static let name: LocalizedStringResource = "Name"
+                    static let identifier: String = "name"
+                    static let category: AccountKeyCategory = .other
+                    static var initialValue: InitialValue<Value> {
+                        .default("Hello World")
+                    }
+                    static let options: AccountKeyOptions = [.read]
+                    struct DataEntry: DataEntryView {
+                        var body: some View {
+                            fatalError("'\\("Name")' does not support write access.")
+                        }
+            
+                        init(_ value: Binding<Value>) {
+                            fatalError("'\\("Name")' does not support write access.")
+                        }
+                    }
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: .write, as: String.self, initial: .default("Hello World"))
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            
+                struct __Key_name: AccountKey {
+                    typealias Value = String
+            
+                    static let name: LocalizedStringResource = "Name"
+                    static let identifier: String = "name"
+                    static let category: AccountKeyCategory = .other
+                    static var initialValue: InitialValue<Value> {
+                        .default("Hello World")
+                    }
+                    static let options: AccountKeyOptions = .write
+                    struct DataDisplay: DataDisplayView {
+                        var body: some View {
+                            fatalError("'\\("Name")' does not support read access.")
+                        }
+            
+                        init(_ value: Value) {
+                            fatalError("'\\("Name")' does not support read access.")
+                        }
+                    }
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+    }
+
+    @Test
+    func testAccountKeyOptionsDiagnostics() {
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: [.read], as: String.self, initial: .default("Hello World"), entryView: CustomView.self)
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot provide a `entryView` if the `@AccountKey` does not specify `read` option.", line: 2, column: 31)
+            ],
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+
+        assertMacroExpansion(
+            """
+            extension AccountDetails {
+                @AccountKey(name: "Name", options: [.write], as: String.self, initial: .default("Hello World"), displayView: CustomView.self)
+                var name: String?
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountDetails {
+                var name: String? {
+                    get {
+                        self[__Key_name.self]
+                    }
+                    set {
+                        self[__Key_name.self] = newValue
+                    }
+                }
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot provide a `displayView` if the `@AccountKey` does not specify `read` option.", line: 2, column: 31)
             ],
             macroSpecs: testMacrosSpecs,
             failureHandler: { Issue.record("\($0.message)") }

--- a/Tests/UITests/TestApp/AccountTestsView.swift
+++ b/Tests/UITests/TestApp/AccountTestsView.swift
@@ -145,9 +145,14 @@ struct AccountTestsView: View {
             }
         }
         let standard = standard
-        if standard.deleteNotified {
+        if standard.hasReportedInformation {
             Section {
-                Text(verbatim: "Got notified about deletion!")
+                if standard.deleteNotified {
+                    Text(verbatim: "Got notified about deletion!")
+                }
+                if standard.suppliedInitialDetails {
+                    Text(verbatim: "Set initial details!")
+                }
             }
         }
     }

--- a/Tests/UITests/TestApp/Features.swift
+++ b/Tests/UITests/TestApp/Features.swift
@@ -22,6 +22,7 @@ enum AccountValueConfigurationType: String, ExpressibleByArgument {
     case `default`
     case allRequired
     case allRequiredWithBio
+    case keysWithOptions
 }
 
 enum DefaultCredentials: String, ExpressibleByArgument {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -72,6 +72,12 @@ class TestAppDelegate: SpeziAppDelegate {
                 .requires(\.biography)
             ]
 #endif
+        case .keysWithOptions:
+            return [
+                .requires(\.userId),
+                .supports(\.displayOnlyOption),
+                .manual(\.mutableOnlyOption)
+            ]
         }
     }
 
@@ -89,7 +95,7 @@ class TestAppDelegate: SpeziAppDelegate {
     }
 
     override var configuration: Configuration {
-        Configuration(standard: TestStandard()) {
+        Configuration(standard: TestStandard(features: self.features)) {
             AccountConfiguration(
                 service: InMemoryAccountService(.emailAddress, configure: provider),
                 storageProvider: InMemoryAccountStorageProvider(),

--- a/Tests/UITests/TestApp/Utils/OptionsKey.swift
+++ b/Tests/UITests/TestApp/Utils/OptionsKey.swift
@@ -1,0 +1,24 @@
+//
+// This source file is part of the Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziAccount
+import SwiftUI
+
+
+extension AccountDetails {
+    @AccountKey(name: "Display-Only", options: .display, as: String.self)
+    var displayOnlyOption: String?
+
+    @AccountKey(name: "Mutable-Only", options: .mutable, as: String.self)
+    var mutableOnlyOption: String?
+}
+
+
+@KeyEntry(\.displayOnlyOption)
+@KeyEntry(\.mutableOnlyOption)
+extension AccountKeys {}

--- a/Tests/UITests/TestApp/Utils/TestStandard.swift
+++ b/Tests/UITests/TestApp/Utils/TestStandard.swift
@@ -17,13 +17,33 @@ actor TestStandard: AccountNotifyConstraint, EnvironmentAccessible {
     @Observable
     final class Storage {
         var deleteNotified = false
+        var suppliedInitialDetails = false
         nonisolated init() {}
     }
 
     private let storage = Storage()
+    private nonisolated let features: Features
+
+    @Application(\.logger)
+    @MainActor private var logger
+
+    @Dependency(InMemoryAccountStorageProvider.self)
+    @MainActor private var storageProvider: InMemoryAccountStorageProvider?
 
     @MainActor var deleteNotified: Bool {
         storage.deleteNotified
+    }
+
+    @MainActor var suppliedInitialDetails: Bool {
+        storage.suppliedInitialDetails
+    }
+
+    @MainActor var hasReportedInformation: Bool {
+        storage.deleteNotified || storage.suppliedInitialDetails
+    }
+
+    init(features: Features) {
+        self.features = features
     }
 
 
@@ -32,6 +52,24 @@ actor TestStandard: AccountNotifyConstraint, EnvironmentAccessible {
         switch event {
         case .deletingAccount:
             storage.deleteNotified = true
+            storage.suppliedInitialDetails = false
+        case let .associatedAccount(details):
+            if features.configurationType == .keysWithOptions {
+                guard let storageProvider else {
+                    logger.error("The account storage provider was never injected!")
+                    break
+                }
+                var modifications = AccountDetails()
+                modifications.displayOnlyOption = "This is displayed."
+                do {
+                    try await storageProvider.simulateRemoteUpdate(for: details.accountId, AccountModifications(modifiedDetails: modifications))
+                    storage.suppliedInitialDetails = true
+                } catch {
+                    logger.error("Failed to updated initial account details: \(error)")
+                }
+            }
+        case .disassociatingAccount:
+            storage.suppliedInitialDetails = false
         default:
             break
         }

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -390,6 +390,24 @@ final class AccountOverviewTests: XCTestCase { // swiftlint:disable:this type_bo
         app.buttons["License Information"].tap()
         XCTAssertTrue(app.navigationBars.staticTexts["Package Dependencies"].waitForExistence(timeout: 3.0))
     }
+
+    @MainActor
+    func testDisplayOnlyOption() throws {
+        let app = XCUIApplication()
+        app.launch(config: .keysWithOptions, credentials: .createAndSignIn)
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Spezi Account"].exists)
+
+        XCTAssertTrue(
+            app.staticTexts["Set initial details!"].waitForExistence(timeout: 2.0),
+            "Application seems to have failed to supply the storage provider with an initial value for the display-only key."
+        )
+
+        app.openAccountOverview()
+
+        XCTAssertTrue(app.staticTexts["Display-Only, This is displayed."].exists)
+    }
 }
 
 

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
@@ -21,6 +21,7 @@ enum Config: String {
     case `default`
     case allRequired
     case allRequiredWithBio
+    case keysWithOptions
 }
 
 enum DefaultCredentials: String {

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
 		2FAD38C02A455FC200E79ED1 /* SpeziAccount in Frameworks */ = {isa = PBXBuildFile; productRef = 2FAD38BF2A455FC200E79ED1 /* SpeziAccount */; };
 		9B345FB82C94BF470067C977 /* InvitationCodeKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B345FB72C94BF470067C977 /* InvitationCodeKey.swift */; };
+		A9684D6C2DE1DBDF00432CD3 /* OptionsKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9684D6B2DE1DBDC00432CD3 /* OptionsKey.swift */; };
 		A969240F2A9A198800E2128B /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = A969240E2A9A198800E2128B /* ArgumentParser */; };
 		A98739032C64EE6000E17A42 /* EntryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98739022C64EE5F00E17A42 /* EntryViewTests.swift */; };
 		A98739052C64F1BB00E17A42 /* EntryViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A98739042C64F1B300E17A42 /* EntryViewsTests.swift */; };
@@ -55,6 +56,7 @@
 		2FE750C92A8720CE00723EAE /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestApp.xctestplan; sourceTree = "<group>"; };
 		636D985F2AF188E00020B8BC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9B345FB72C94BF470067C977 /* InvitationCodeKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvitationCodeKey.swift; sourceTree = "<group>"; };
+		A9684D6B2DE1DBDC00432CD3 /* OptionsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionsKey.swift; sourceTree = "<group>"; };
 		A98739022C64EE5F00E17A42 /* EntryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewTests.swift; sourceTree = "<group>"; };
 		A98739042C64F1B300E17A42 /* EntryViewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryViewsTests.swift; sourceTree = "<group>"; };
 		A9B6E3F62A9B6F5B0008B232 /* AccountSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSetupTests.swift; sourceTree = "<group>"; };
@@ -93,6 +95,7 @@
 		2F027C9629D6C63300234098 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				A9684D6B2DE1DBDC00432CD3 /* OptionsKey.swift */,
 				A9B6E3FC2A9B74830008B232 /* BiographyKey.swift */,
 				9B345FB72C94BF470067C977 /* InvitationCodeKey.swift */,
 				A9B6E3FE2A9B795C0008B232 /* TestStandard.swift */,
@@ -284,6 +287,7 @@
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				A98739032C64EE6000E17A42 /* EntryViewTests.swift in Sources */,
 				A9EE7D2A2A3359E800C2B9A9 /* Features.swift in Sources */,
+				A9684D6C2DE1DBDF00432CD3 /* OptionsKey.swift in Sources */,
 				9B345FB82C94BF470067C977 /* InvitationCodeKey.swift in Sources */,
 				2F027C9529D6C63100234098 /* TestAppDelegate.swift in Sources */,
 				2F027C8929D6C2AD00234098 /* AccountDetails+Default.swift in Sources */,

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -82,6 +82,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "keysWithOptions"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "allRequired"
             isEnabled = "NO">
          </CommandLineArgument>


### PR DESCRIPTION
# Allow to specify and customize display and mutation behavior of Account Keys

## :recycle: Current situation & Problem
An AccountKey was always assumed to be mutable and the `AccountConfiguration` fully dictated if it was displayed to the user or not.
This PR adds a new optional `options` requirement to `AccountKey`s that allows to specify this behavior by two new options `display` and `mutable`. Refer to the inline documentation for the exact semantic of these two options. `[.display, .mutable]` will stay the default.

```swift
/// The account key supports to be displayed to the user.
///
/// An Account Key always implicitly supports read access. Therefore, when `display` is supported, a ``DataDisplayView`` is required to be specified (or relying on a default implementation fo
/// the given type).
/// If ``mutable`` option is set as well, a ``DataEntryView`` is likewise required to be specified.
public static let display = AccountKeyOptions(rawValue: 1 << 0)
/// The account key supports mutation.
///
/// This option marks the account key to support user-initiated (or think of as client-side initiated) mutation.
/// Having this option not set does not prevent server-side permutation (e.g., as a side effect of some request).
/// Instead it makes it explicit that the user (or rather client-side code) is allowed to mutate the value themselves (assuming some authorization checks).
///
/// If the the ``display`` option is set, you must supply a ``DataEntryView`` to allow permutation from UI.
public static let mutable = AccountKeyOptions(rawValue: 1 << 1)
```

Specifically, this allows to explicitly model account keys that do not require to implement a `DataDisplay` and/or `DataEntry` view and to implement read-only account keys (e.g., account value that are not meant to be updated from the client side; note, this doesn't mandate that the value might be not mutated on the server-side, e.g., through some  operation that performs additional validation).

## :gear: Release Notes
* Add new `options` to `AccountKey`s.

## :books: Documentation
DocC catalog was updated respectively.


## :white_check_mark: Testing
We added tests for the new changes in the macro implementation.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
