### PR TITLE
Introduce `SetupDisplayView` protocol as a way to provide a setup view for account details

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,5 +12,5 @@ Spezi Account Contributors
 ====================
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
-* [Andreas Bauer](https://github.com/Supereg)
+* [Andreas Bauer](https://github.com/bauer-andreas)
 * [Nikolai Madlener](https://github.com/NikolaiMadlener)

--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,7 @@ let package = Package(
                 .target(name: "SpeziAccount"),
                 .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions"),
                 .product(name: "Spezi", package: "Spezi"),
-                .product(name: "XCTSpezi", package: "Spezi"),
+                .product(name: "SpeziTesting", package: "Spezi"),
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing")
             ],
             resources: [

--- a/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
@@ -57,6 +57,11 @@ extension AccountKey {
         return nil
     }
 
+    static func hasSetupView() -> Bool {
+        let typeWrapper = AccountKeyTypeWrapper<Self>()
+        return typeWrapper is any AccountKeyWithSetupView
+    }
+
     static func singleEditView(model: AccountOverviewFormViewModel, details accountDetails: AccountDetails) -> AnyView {
         AnyView(SingleEditView<Self>(model: model, details: accountDetails))
     }

--- a/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
@@ -73,4 +73,3 @@ extension AccountKeyTypeWrapper: AccountKeyWithSetupView where Key.DataDisplay: 
         AnyView(Key.DataDisplay(nil))
     }
 }
-

--- a/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKey+Views.swift
@@ -9,6 +9,15 @@
 import SpeziFoundation
 import SwiftUI
 
+protocol AccountKeyWithSetupView {
+    @MainActor
+    func emptySetupView() -> AnyView
+}
+
+private struct AccountKeyTypeWrapper<Key: AccountKey> {
+    init() {}
+}
+
 
 @MainActor
 extension AccountKey {
@@ -39,7 +48,24 @@ extension AccountKey {
         return AnyView(DataDisplay(value))
     }
 
+    static func setupView() -> AnyView? {
+        let typeWrapper = AccountKeyTypeWrapper<Self>()
+
+        if let setupTypeWrapper = typeWrapper as? any AccountKeyWithSetupView {
+            return setupTypeWrapper.emptySetupView()
+        }
+        return nil
+    }
+
     static func singleEditView(model: AccountOverviewFormViewModel, details accountDetails: AccountDetails) -> AnyView {
         AnyView(SingleEditView<Self>(model: model, details: accountDetails))
     }
 }
+
+extension AccountKeyTypeWrapper: AccountKeyWithSetupView where Key.DataDisplay: SetupDisplayView {
+    @MainActor
+    func emptySetupView() -> AnyView {
+        AnyView(Key.DataDisplay(nil))
+    }
+}
+

--- a/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
+++ b/Sources/SpeziAccount/AccountValue/AccountKeyMacros.swift
@@ -219,6 +219,6 @@ public macro AccountKey<Value: ExpressibleByArrayLiteral, DataDisplay: DataDispl
 ///
 /// - Parameter key: The KeyPath to the AccountKey defined on the ``AccountDetails``.
 @attached(member, names: arbitrary)
-public macro KeyEntry<Value>(
-    _ key: KeyPath<AccountDetails, Value>
+public macro KeyEntry<each Value>(
+    _ key: repeat KeyPath<AccountDetails, each Value>
 ) = #externalMacro(module: "SpeziAccountMacros", type: "KeyEntryMacro")

--- a/Sources/SpeziAccount/ExternalAccountStorage.swift
+++ b/Sources/SpeziAccount/ExternalAccountStorage.swift
@@ -27,7 +27,7 @@ import Spezi
 ///
 /// ### Communicate changes as a Storage Provider
 /// - ``notifyAboutUpdatedDetails(for:_:)``
-public final class ExternalAccountStorage {
+public final class ExternalAccountStorage: Module, Sendable {
     /// Capture details that are externally stored, associated with their account id.
     public struct ExternallyStoredDetails: Sendable {
         /// The account id the storage details are associated with.
@@ -184,6 +184,3 @@ public final class ExternalAccountStorage {
         await storageProvider?.disassociate(accountId)
     }
 }
-
-
-extension ExternalAccountStorage: Module, Sendable {}

--- a/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
+++ b/Sources/SpeziAccount/Mock/InMemoryAccountStorageProvider.swift
@@ -13,7 +13,7 @@ import Spezi
 ///
 /// This ``AccountStorageProvider`` is implemented using an in-memory stored dictionary of ``AccountDetails``. It serves as a minimal
 /// example on how to implement a external storage provider and can be easily integrated in SwiftUI previews and UI tests.
-public actor InMemoryAccountStorageProvider: AccountStorageProvider {
+public actor InMemoryAccountStorageProvider: AccountStorageProvider, EnvironmentAccessible {
     private var records: [String: AccountDetails] = [:]
     private var cache: [String: AccountDetails] = [:] // simulates an in-memory cache
 

--- a/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
+++ b/Sources/SpeziAccount/SpeziAccount.docc/AccountKey/Adding new Account Values.md
@@ -193,6 +193,7 @@ Still, you are required to evaluate to which extent validation has to be handled
 ### Displaying Account Keys
 
 - ``DataDisplayView``
+- ``SetupDisplayView``
 - ``StringDisplayView``
 - ``BoolDisplayView``
 - ``FixedWidthIntegerDisplayView``

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -54,14 +54,8 @@ struct AccountKeyOverviewRow: View {
             } else {
                 hStack
             }
-        } else {
-            Group {
-                if let view = accountKey.dataDisplayViewWithCurrentStoredValue(from: accountDetails) {
-                    view
-                } else if let setupView = accountKey.setupView() {
-                    setupView
-                }
-            }
+        } else if let view = accountKey.dataDisplayViewWithCurrentStoredValue(from: accountDetails) ?? accountKey.setupView() {
+            view
                 .deleteDisabled(true) // e.g., prevent deletion of non-mutable account keys
                 .disabled(editMode?.wrappedValue.isEditing == true)
                 .environment(\.accountViewType, .overview(mode: .display))

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -55,10 +55,16 @@ struct AccountKeyOverviewRow: View {
                 hStack
             }
         } else {
-            if let view = accountKey.dataDisplayViewWithCurrentStoredValue(from: accountDetails) {
-                view
-                    .environment(\.accountViewType, .overview(mode: .display))
+            Group {
+                if let view = accountKey.dataDisplayViewWithCurrentStoredValue(from: accountDetails) {
+                    view
+                } else if let setupView = accountKey.setupView() {
+                    setupView
+                }
             }
+                .deleteDisabled(true) // e.g., prevent deletion of non-mutable account keys
+                .disabled(editMode?.wrappedValue.isEditing == true) // TODO: should we force that?
+                .environment(\.accountViewType, .overview(mode: .display))
         }
     }
 

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountKeyOverviewRow.swift
@@ -63,7 +63,7 @@ struct AccountKeyOverviewRow: View {
                 }
             }
                 .deleteDisabled(true) // e.g., prevent deletion of non-mutable account keys
-                .disabled(editMode?.wrappedValue.isEditing == true) // TODO: should we force that?
+                .disabled(editMode?.wrappedValue.isEditing == true)
                 .environment(\.accountViewType, .overview(mode: .display))
         }
     }

--- a/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
+++ b/Sources/SpeziAccount/Views/AccountOverview/AccountOverviewSections.swift
@@ -178,7 +178,7 @@ struct AccountOverviewSections<AdditionalSections: View>: View {
         
         // we don't have to check for `addedAccountKeys` as these are only relevant in edit mode
         return accountKeys.allSatisfy { element in
-            !accountDetails.contains(element)
+            !accountDetails.contains(element) && !element.hasSetupView()
         }
     }
 }

--- a/Sources/SpeziAccount/Views/DataDisplay/SetupDisplayView.swift
+++ b/Sources/SpeziAccount/Views/DataDisplay/SetupDisplayView.swift
@@ -26,7 +26,8 @@ public protocol SetupDisplayView<Value>: DataDisplayView {
 }
 
 extension SetupDisplayView {
-   public init(_ value: Value) { // default implementation for `DataDisplayView`.
-      self.init(.some(value))
-   }
+    /// Default implementation with a required value.
+    public init(_ value: Value) { // default implementation for `DataDisplayView`.
+        self.init(.some(value))
+    }
 }

--- a/Sources/SpeziAccount/Views/DataDisplay/SetupDisplayView.swift
+++ b/Sources/SpeziAccount/Views/DataDisplay/SetupDisplayView.swift
@@ -1,0 +1,32 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziFoundation
+import SpeziViews
+import SwiftUI
+
+/// A view that handles setup and display of an `AccountKey`.
+///
+/// While a ``DataDisplayView`` is only displayed, if a value is present in the ``AccountDetails`` of a user,
+/// this view is also displayed to set up a account value that is not yet added to the account details of a user.
+///
+/// This view is used in the ``AccountOverview`` to show a setup interface for account keys
+/// that don't have a stored value yet.
+public protocol SetupDisplayView<Value>: DataDisplayView {
+    /// Create a new setup display view.
+    /// - Parameters:
+    ///   - value: The current account value or `nil`, if the account details do not have a value for the given `AccountKey`.
+    @MainActor
+    init(_ value: Value?)
+}
+
+extension SetupDisplayView {
+   public init(_ value: Value) { // default implementation for `DataDisplayView`.
+      self.init(.some(value))
+   }
+}

--- a/Sources/SpeziAccountMacros/KeyEntryMacro.swift
+++ b/Sources/SpeziAccountMacros/KeyEntryMacro.swift
@@ -35,7 +35,7 @@ extension KeyEntryMacro: MemberMacro {
               let propertyComponent = component.component.as(KeyPathPropertyComponentSyntax.self) else {
             throw DiagnosticsError(
                 syntax: argument.expression,
-                message: "'@KeyEntry' failed to parse the keypath expression in argument 'key'",
+                message: "'@KeyEntry' failed to parse the KeyPath expression in argument 'key'",
                 id: .invalidSyntax
             )
         }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -247,14 +247,28 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                         .default(.preferNotToState)
                     }
                     public static let options: AccountKeyOptions = .default
-                    public struct DataDisplay: DataDisplayView {
-                        private let value: Value
-
+                    public struct DataDisplay: SetupDisplayView {
+                        public typealias Value = GenderIdentity
+            
+                        private let value: Value?
+            
                         public var body: some View {
-                            TestDisplayUI(value)
+                            if let value {
+                                TestDisplayUI(value)
+                            } else {
+                                makeSetupView(for: TestDisplayUI.self)
+                            }
                         }
-
-                        public init(_ value: Value) {
+            
+                        private func makeSetupView<T: DataDisplayView>(for type: T.Type) -> some View {
+                            EmptyView()
+                        }
+            
+                        private func makeSetupView<T: SetupDisplayView>(for type: T.Type) -> some View {
+                            T(nil)
+                        }
+            
+                        public init(_ value: Value?) {
                             self.value = value
                         }
                     }
@@ -315,14 +329,28 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
                         .default(.preferNotToState)
                     }
                     static let options: AccountKeyOptions = .default
-                    struct DataDisplay: DataDisplayView {
-                        private let value: Value
+                    struct DataDisplay: SetupDisplayView {
+                        typealias Value = GenderIdentity
+            
+                        private let value: Value?
             
                         var body: some View {
-                            DataDisplay(value)
+                            if let value {
+                                DataDisplay(value)
+                            } else {
+                                makeSetupView(for: DataDisplay.self)
+                            }
                         }
             
-                        init(_ value: Value) {
+                        private func makeSetupView<T: DataDisplayView>(for type: T.Type) -> some View {
+                            EmptyView()
+                        }
+            
+                        private func makeSetupView<T: SetupDisplayView>(for type: T.Type) -> some View {
+                            T(nil)
+                        }
+            
+                        init(_ value: Value?) {
                             self.value = value
                         }
                     }

--- a/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
+++ b/Tests/SpeziAccountMacrosTests/AccountKeyMacroTests.swift
@@ -674,6 +674,48 @@ struct AccountKeyMacroTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
+    func testAccountKeyEntriesParameterPack() {
+        assertMacroExpansion(
+            """
+            @KeyEntry(\\.genderIdentity, \\.name, \\.dateOfBirth)
+            extension AccountKeys {
+            }
+            """,
+            expandedSource:
+            """
+            extension AccountKeys {
+            
+                var genderIdentity: AccountDetails.__Key_genderIdentity.Type {
+                    AccountDetails.__Key_genderIdentity.self
+                }
+            
+                static var genderIdentity: AccountDetails.__Key_genderIdentity.Type {
+                    AccountDetails.__Key_genderIdentity.self
+                }
+            
+                var name: AccountDetails.__Key_name.Type {
+                    AccountDetails.__Key_name.self
+                }
+            
+                static var name: AccountDetails.__Key_name.Type {
+                    AccountDetails.__Key_name.self
+                }
+            
+                var dateOfBirth: AccountDetails.__Key_dateOfBirth.Type {
+                    AccountDetails.__Key_dateOfBirth.self
+                }
+            
+                static var dateOfBirth: AccountDetails.__Key_dateOfBirth.Type {
+                    AccountDetails.__Key_dateOfBirth.self
+                }
+            }
+            """,
+            macroSpecs: testMacrosSpecs,
+            failureHandler: { Issue.record("\($0.message)") }
+        )
+    }
+
+    @Test
     func testGeneralDiagnostics() { // swiftlint:disable:this function_body_length
         assertMacroExpansion(
             """

--- a/Tests/SpeziAccountTests/AccountDetailsCacheTests.swift
+++ b/Tests/SpeziAccountTests/AccountDetailsCacheTests.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 @testable import SpeziAccount
+import SpeziTesting
 import Testing
-import XCTSpezi
 
 @Suite("AccountDetails Cache Tests", .serialized)
 struct AccountDetailsCacheTests {

--- a/Tests/SpeziAccountTests/AccountNotificationsTests.swift
+++ b/Tests/SpeziAccountTests/AccountNotificationsTests.swift
@@ -8,8 +8,8 @@
 
 import Spezi
 @testable import SpeziAccount
+import SpeziTesting
 import Testing
-import XCTSpezi
 
 private final class TestProvider: AccountStorageProvider {
     private let onDisassociate: Testing.Confirmation

--- a/Tests/SpeziAccountTests/SnapshotTesting.swift
+++ b/Tests/SpeziAccountTests/SnapshotTesting.swift
@@ -10,9 +10,9 @@ import SnapshotTesting
 @_spi(_Testing)
 @_spi(TestingSupport)
 @testable import SpeziAccount
+import SpeziTesting
 import SwiftUI
 import Testing
-import XCTSpezi
 
 #if os(iOS)
 let isRunningIOS = true

--- a/Tests/UITests/TestApp/Features.swift
+++ b/Tests/UITests/TestApp/Features.swift
@@ -23,6 +23,7 @@ enum AccountValueConfigurationType: String, ExpressibleByArgument {
     case allRequired
     case allRequiredWithBio
     case keysWithOptions
+    case withSetupView
 }
 
 enum DefaultCredentials: String, ExpressibleByArgument {

--- a/Tests/UITests/TestApp/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/TestAppDelegate.swift
@@ -78,6 +78,11 @@ class TestAppDelegate: SpeziAppDelegate {
                 .supports(\.displayOnlyOption),
                 .manual(\.mutableOnlyOption)
             ]
+        case .withSetupView:
+            return [
+                .requires(\.userId),
+                .supports(\.setupDisplayOnly)
+            ]
         }
     }
 

--- a/Tests/UITests/TestApp/Utils/OptionsKey.swift
+++ b/Tests/UITests/TestApp/Utils/OptionsKey.swift
@@ -7,18 +7,35 @@
 //
 
 import SpeziAccount
+import SpeziViews
 import SwiftUI
 
 struct SetupButtonStringView: SetupDisplayView {
     typealias Value = String
 
+    @Environment(InMemoryAccountStorageProvider.self)
+    private var externalAccountStorage
+    @Environment(Account.self)
+    private var account
+
     private let value: String?
+
+    @State private var viewState: ViewState = .idle
 
     var body: some View {
         if let value {
             LabeledContent("Value", value: value)
+                .accessibilityElement(children: .combine)
         } else {
-            Button("Guided Setup") {}
+            AsyncButton("Guided Setup", state: $viewState) {
+                guard let details = account.details else {
+                    return
+                }
+
+                var modifications = AccountDetails()
+                modifications.setupDisplayOnly = "Hello, World!"
+                try await externalAccountStorage.simulateRemoteUpdate(for: details.accountId, AccountModifications(modifiedDetails: modifications))
+            }
         }
     }
 

--- a/Tests/UITests/TestApp/Utils/OptionsKey.swift
+++ b/Tests/UITests/TestApp/Utils/OptionsKey.swift
@@ -9,6 +9,24 @@
 import SpeziAccount
 import SwiftUI
 
+struct SetupButtonStringView: SetupDisplayView {
+    typealias Value = String
+
+    private let value: String?
+
+    var body: some View {
+        if let value {
+            LabeledContent("Value", value: value)
+        } else {
+            Button("Guided Setup") {}
+        }
+    }
+
+    init(_ value: String?) {
+        self.value = value
+    }
+}
+
 
 extension AccountDetails {
     @AccountKey(name: "Display-Only", options: .display, as: String.self)
@@ -16,9 +34,14 @@ extension AccountDetails {
 
     @AccountKey(name: "Mutable-Only", options: .mutable, as: String.self)
     var mutableOnlyOption: String?
+
+    @AccountKey(name: "Setup-Display-Only", options: .display, as: String.self, displayView: SetupButtonStringView.self)
+    var setupDisplayOnly: String?
 }
 
 
+// TODO: support syntax @KeyEntry(\.displayOnlyOption, \.mutableOnlyOption, \.setupDisplayOnly)
 @KeyEntry(\.displayOnlyOption)
 @KeyEntry(\.mutableOnlyOption)
+@KeyEntry(\.setupDisplayOnly)
 extension AccountKeys {}

--- a/Tests/UITests/TestApp/Utils/OptionsKey.swift
+++ b/Tests/UITests/TestApp/Utils/OptionsKey.swift
@@ -40,8 +40,5 @@ extension AccountDetails {
 }
 
 
-// TODO: support syntax @KeyEntry(\.displayOnlyOption, \.mutableOnlyOption, \.setupDisplayOnly)
-@KeyEntry(\.displayOnlyOption)
-@KeyEntry(\.mutableOnlyOption)
-@KeyEntry(\.setupDisplayOnly)
+@KeyEntry(\.displayOnlyOption, \.mutableOnlyOption, \.setupDisplayOnly)
 extension AccountKeys {}

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -408,6 +408,19 @@ final class AccountOverviewTests: XCTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertTrue(app.staticTexts["Display-Only, This is displayed."].exists)
     }
+
+    @MainActor
+    func testSetupView() throws {
+        let app = XCUIApplication()
+        app.launch(config: .withSetupView, credentials: .createAndSignIn)
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Spezi Account"].exists)
+
+        app.openAccountOverview()
+
+        XCTAssertTrue(app.buttons["Guided Setup"].waitForExistence(timeout: 2.0))
+    }
 }
 
 

--- a/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
+++ b/Tests/UITests/TestAppUITests/AccountOverviewTests.swift
@@ -420,6 +420,9 @@ final class AccountOverviewTests: XCTestCase { // swiftlint:disable:this type_bo
         app.openAccountOverview()
 
         XCTAssertTrue(app.buttons["Guided Setup"].waitForExistence(timeout: 2.0))
+        app.buttons["Guided Setup"].tap()
+
+        XCTAssertTrue(app.staticTexts["Value, Hello, World!"].waitForExistence(timeout: 2.0))
     }
 }
 

--- a/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
+++ b/Tests/UITests/TestAppUITests/Utils/XCUIApplication+TestApp.swift
@@ -22,6 +22,7 @@ enum Config: String {
     case allRequired
     case allRequiredWithBio
     case keysWithOptions
+    case withSetupView
 }
 
 enum DefaultCredentials: String {

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -86,6 +86,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "withSetupView"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "allRequired"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -98,7 +102,7 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "create"
+            argument = "createAndSignIn"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument


### PR DESCRIPTION
# Introduce `SetupDisplayView` protocol as a way to provide a setup view for account details

## :recycle: Current situation & Problem
Currently, the `DataDisplay` view of an account key is only drawn if there is a value added to the `AccountDetails` of a user. This PR adds a new optional protocol you can conform your display view to that allows to also draw UI if the an account value is not yet present. In combination with `display-only` account keys, this can be used to exclusively provide a custom setup experience for an account key.

## :gear: Release Notes
* Add `SetupDisplayView` as an additional conformance for the display view of an account key.
* `@KeyEntry` macro now supports variadic arguments through Parameter Packs.

## :books: Documentation
Updated docs catalog.

## :white_check_mark: Testing
Added UI tests to verify SetupDisplayView is rendered and updated unit tests for macros.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
